### PR TITLE
adding missing target from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ to authenticate with Rootly without exposing your API key to users.
 # app-config.yaml
 proxy:
   '/rootly/api':
+    target: https://api.rootly.com
     headers:
       Authorization: Bearer ${ROOTLY_API_KEY}
 ```


### PR DESCRIPTION
Hi team,  

After following the instructions on the readme, I realized that the plugin wasn't working, as the target was missing from the configuration. 