### PR TITLE
Remove unused lerna dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "concurrently": "^8.2.2",
     "history": "^5.0.0",
     "install": "^0.13.0",
-    "lerna": "^8.0.2",
     "moment": "^2.29.1",
     "prettier": "^3.1.1",
     "qs": "^6.10.3",


### PR DESCRIPTION
lerna brings in the `ip` package which has an unfixed security vulnerability. It appears to be unused in this project so it looks like it can be removed? You could always install it globally for ad hoc use but this project doesn't seem to use workspaces so I think it's safe to remove.