### PR TITLE
fix: Adds default kind to the link for the Backstage entity in the service…

### DIFF
--- a/src/components/ServicesTable/ServicesTable.tsx
+++ b/src/components/ServicesTable/ServicesTable.tsx
@@ -108,7 +108,7 @@ export const ServicesTable = ({
     if (rowData.attributes.backstage_id) {
       return (
         <EntityRefLink
-          entityRef={parseEntityRef(rowData.attributes.backstage_id)}
+          entityRef={parseEntityRef(rowData.attributes.backstage_id, {defaultKind="component" })}
         />
       );
     }


### PR DESCRIPTION
Fixes issue that is raised when opening `/rootly/services` like:
`
Entity reference "0d24e779-8178-4205-946b-117ec8bfa3ef" had missing or empty kind (e.g. did not start with "component:" or similar)
`