### PR TITLE
Bump react-router and react-router-dom from 6.30.1 to 7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react-router": "^6.0.0",
-    "react-router-dom": "^6.0.0"
+    "react-router": "^6.0.0 || ^7.0.0",
+    "react-router-dom": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.36.2",
@@ -105,8 +105,8 @@
     "jest-fetch-mock": "^3.0.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-router": "^6.30.1",
-    "react-router-dom": "^6.30.1",
+    "react-router": "^7.16.0",
+    "react-router-dom": "^7.16.0",
     "swr": "^2.4.1",
     "typescript": "^6.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3655,13 +3655,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.0":
-  version: 1.23.0
-  resolution: "@remix-run/router@npm:1.23.0"
-  checksum: 10c0/eaef5cb46a1e413f7d1019a75990808307e08e53a39d4cf69c339432ddc03143d725decef3d6b9b5071b898da07f72a4a57c4e73f787005fcf10162973d8d7d7
-  languageName: node
-  linkType: hard
-
 "@remixicon/react@npm:>=4.6.0 <4.9.0":
   version: 4.8.0
   resolution: "@remixicon/react@npm:4.8.0"
@@ -3986,16 +3979,16 @@ __metadata:
     react: "npm:^19.2.7"
     react-chartkick: "npm:^0.5.4"
     react-dom: "npm:^19.2.7"
-    react-router: "npm:^6.30.1"
-    react-router-dom: "npm:^6.30.1"
+    react-router: "npm:^7.16.0"
+    react-router-dom: "npm:^7.16.0"
     react-use: "npm:^17.6.0"
     swr: "npm:^2.4.1"
     typescript: "npm:^6.0.3"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-router: ^6.0.0
-    react-router-dom: ^6.0.0
+    react-router: ^6.0.0 || ^7.0.0
+    react-router-dom: ^6.0.0 || ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -7084,6 +7077,13 @@ __metadata:
   version: 1.0.7
   resolution: "cookie-signature@npm:1.0.7"
   checksum: 10c0/e7731ad2995ae2efeed6435ec1e22cdd21afef29d300c27281438b1eab2bae04ef0d1a203928c0afec2cee72aa36540b8747406ebe308ad23c8e8cc3c26c9c51
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^1.0.1":
+  version: 1.1.1
+  resolution: "cookie@npm:1.1.1"
+  checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
   languageName: node
   linkType: hard
 
@@ -14884,27 +14884,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^6.30.1":
-  version: 6.30.1
-  resolution: "react-router-dom@npm:6.30.1"
+"react-router-dom@npm:^7.16.0":
+  version: 7.17.0
+  resolution: "react-router-dom@npm:7.17.0"
   dependencies:
-    "@remix-run/router": "npm:1.23.0"
-    react-router: "npm:6.30.1"
+    react-router: "npm:7.17.0"
   peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-  checksum: 10c0/e9e1297236b0faa864424ad7d51c392fc6e118595d4dad4cd542fd217c479a81601a81c6266d5801f04f9e154de02d3b094fc22ccb544e755c2eb448fab4ec6b
+    react: ">=18"
+    react-dom: ">=18"
+  checksum: 10c0/60fc4022bccf2fb17b0d8ae8e7c4bda866ca9bf2d45edf0bcbefc854e97fa8971a589b6b77b984a19abecb718faffde357c829d9a22a7913790d608cc7433714
   languageName: node
   linkType: hard
 
-"react-router@npm:6.30.1, react-router@npm:^6.30.1":
-  version: 6.30.1
-  resolution: "react-router@npm:6.30.1"
+"react-router@npm:7.17.0, react-router@npm:^7.16.0":
+  version: 7.17.0
+  resolution: "react-router@npm:7.17.0"
   dependencies:
-    "@remix-run/router": "npm:1.23.0"
+    cookie: "npm:^1.0.1"
+    set-cookie-parser: "npm:^2.6.0"
   peerDependencies:
-    react: ">=16.8"
-  checksum: 10c0/0414326f2d8e0c107fb4603cf4066dacba6a1f6f025c6e273f003e177b2f18888aca3de06d9b5522908f0e41de93be1754c37e82aa97b3a269c4742c08e82539
+    react: ">=18"
+    react-dom: ">=18"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10c0/dfa9b0182edba6fab14ef5ac297b292068e71e05bf7e07c6b45fe073d77002089e8e164542364232a8bbb0c7d3ec47b57b78db3984c4383e12308f2d31ad404a
   languageName: node
   linkType: hard
 
@@ -15978,6 +15982,13 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:~0.19.1"
   checksum: 10c0/36320397a073c71bedf58af48a4a100fe6d93f07459af4d6f08b9a7217c04ce2a4939e0effd842dc7bece93ffcd59eb52f58c4fff2a8e002dc29ae6b219cd42b
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.6.0":
+  version: 2.7.2
+  resolution: "set-cookie-parser@npm:2.7.2"
+  checksum: 10c0/4381a9eb7ee951dfe393fe7aacf76b9a3b4e93a684d2162ab35594fa4053cc82a4d7d7582bf397718012c9adcf839b8cd8f57c6c42901ea9effe33c752da4a45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bump `react-router` and `react-router-dom` from 6.30.1 to 7.x (resolved: 7.17.0)
- Widen `peerDependencies` to `^6.0.0 || ^7.0.0` so consumers on either major version are supported
- Replaces Dependabot PRs #122 and #123 (closed — they bumped each package separately but they must move together)

## Notes

- Only 3 react-router imports in the codebase (`useNavigate`, `useOutlet`) — all exist in v7 unchanged
- Type-check shows same 16 pre-existing errors on both master and this branch (no regressions)
- This is a **minor version bump for the plugin** since peerDependencies are widened (not narrowed)

## Test plan

- [x] `yarn install` succeeds
- [x] `tsc --noEmit` — no new type errors vs master (16 pre-existing on both)
- [ ] CI passes