### PR TITLE
Prepare 1.3.1 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,10 @@ jobs:
           node-version: 24
           cache: yarn
       - run: npm install -g npm@latest
+      - run: corepack enable
       - run: yarn install --immutable
+      - run: yarn lint
+      - run: yarn test --watchAll=false
       - run: yarn build
+      - run: npm publish --dry-run --access public
       - run: npm publish --provenance --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @rootly/backstage-plugin
 
+## 1.3.1
+
+- Refresh vulnerable transitive dependencies and development tooling
+- Upgrade Jest DOM and fetch mocking dependencies with compatibility fixes
+- Preserve React Router 7 and supported Backstage peer ranges
+- Migrate navigation metadata to the current Backstage frontend API
+
 ## 1.3.0
 
 - Add catalog entity support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rootly/backstage-plugin",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump @rootly/backstage-plugin to 1.3.1
- document dependency and Backstage frontend API maintenance
- add lint, tests, and npm package dry-run gates to the release workflow

## Compatibility

Patch release with no supported public API break. React Router 7 and the supported Backstage peer ranges remain unchanged.

## Validation

- yarn install --immutable
- yarn lint (0 errors; existing deprecation warnings only)
- yarn test --watchAll=false
- yarn build
- npm 12.0.2 publish --dry-run --access public
- actionlint