### PR TITLE
Enable Corepack before Yarn cache setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: corepack enable
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24


### PR DESCRIPTION
## Summary

- enable Corepack before setup-node evaluates the Yarn cache
- retain Corepack initialization after the npm upgrade

## Cause

The v1.3.1 release workflow stopped in setup-node because the runner selected global Yarn 1 before Corepack could activate the package-managed Yarn 4.9.4.

## Validation

- corepack enable
- yarn --version (4.9.4)
- actionlint
- git diff --check