### PR TITLE
Fix Rootly API key config visibility

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -15,14 +15,18 @@
  */
 
 export interface Config {
-  /**
-   * @deepVisibility frontend
-   **/
   rootly?: {
     [key: string]: {
+      /** @visibility frontend */
       isDefault?: boolean;
-      apiKey: string;
+      /**
+       * @deprecated API keys are configured on the Backstage proxy endpoint.
+       * @visibility secret
+       */
+      apiKey?: string;
+      /** @visibility frontend */
       proxyPath?: string;
+      /** @visibility frontend */
       apiHost?: string;
     };
   };


### PR DESCRIPTION
## Summary

- make the unused `apiKey` setting optional and deprecated
- mark legacy `apiKey` values as secret so they are excluded from frontend configuration
- replace broad `rootly` deep frontend visibility with property-level visibility for `isDefault`, `proxyPath`, and `apiHost`

## Why

The client moved from direct Rootly API-key authentication to the Backstage proxy and identity token flow, but the old required schema field remained. This made the documented proxy-only configuration fail strict validation and could expose a real token through frontend-visible configuration.

Keeping the field as an optional secret preserves compatibility with existing installations while preventing browser exposure.

Fixes #153.

## Validation

- `backstage-cli config:check --strict` passes for the documented proxy-only configuration
- strict validation also passes for legacy configurations containing `apiKey`
- `backstage-cli config:print --frontend` omits `apiKey` while retaining `proxyPath`
- `yarn tsc`
- `yarn lint` (passes with existing React import warnings)
- `yarn build`
- `yarn test --watchAll=false` is currently blocked by the existing `html-encoding-sniffer` CommonJS/ESM incompatibility
