### PR TITLE
Prepare 1.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rootly/backstage-plugin
 
+## 1.3.2
+
+- Allow the documented proxy-only Rootly configuration to pass strict validation
+- Keep the legacy `apiKey` setting optional and secret so it is not exposed to the frontend
+- Refresh minor and patch development dependencies
+
 ## 1.3.1
 
 - Refresh vulnerable transitive dependencies and development tooling

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rootly/backstage-plugin",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump `@rootly/backstage-plugin` from 1.3.1 to 1.3.2
- document the proxy-only configuration and API key visibility fix
- include the minor and patch development dependency refreshes merged since 1.3.1

## Impact

This patch release makes the documented Rootly proxy configuration pass strict validation while preserving compatibility for legacy `apiKey` settings and preventing those values from reaching frontend configuration.

## Validation

- immutable dependency install on Node 24.15.0
- lint (existing warnings only)
- tests
- package build
- npm publish dry-run for `@rootly/backstage-plugin@1.3.2`
