### PR TITLE
Add plugin contract tests and PR verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,17 @@
-name: Publish
+name: CI
 
 on:
-  release:
-    types: [published]
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
 
 jobs:
-  publish:
+  verify:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: corepack enable
@@ -18,11 +19,8 @@ jobs:
         with:
           node-version: 24
           cache: yarn
-      - run: npm install -g npm@latest
-      - run: corepack enable
       - run: yarn install --immutable
       - run: yarn lint
       - run: yarn test --watchAll=false
       - run: yarn build
       - run: npm publish --dry-run --access public
-      - run: npm publish --provenance --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
           cache: yarn
       - run: yarn install --immutable
       - run: yarn lint
-      - run: yarn test --watchAll=false
+      - run: yarn test --watchAll=false --coverage --coverageReporters=text-summary
       - run: yarn build
       - run: npm pack --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
       - run: yarn lint
       - run: yarn test --watchAll=false
       - run: yarn build
-      - run: npm publish --dry-run --access public
+      - run: npm pack --dry-run

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "branches": 25,
-        "functions": 25,
-        "lines": 35,
-        "statements": 35
+        "branches": 70,
+        "functions": 60,
+        "lines": 75,
+        "statements": 75
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@backstage/core-app-api": "^1.20.3",
     "@backstage/dev-utils": "^1.1.25",
     "@backstage/frontend-defaults": "^0.5.4",
+    "@backstage/frontend-test-utils": "^0.6.2",
     "@backstage/plugin-catalog": "^2.0.7",
     "@backstage/plugin-search": "^1.7.6",
     "@backstage/test-utils": "^1.7.20",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,16 @@
     "plugin",
     "rootly"
   ],
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "branches": 25,
+        "functions": 25,
+        "lines": 35,
+        "statements": 35
+      }
+    }
+  },
   "sideEffects": false,
   "scripts": {
     "start": "backstage-cli package start --config ./dev/app-config.yaml",
@@ -86,6 +96,7 @@
   "devDependencies": {
     "@backstage/cli": "^0.36.4",
     "@backstage/cli-defaults": "^0.1.4",
+    "@backstage/config-loader": "^1.11.0",
     "@backstage/core-app-api": "^1.20.3",
     "@backstage/dev-utils": "^1.1.25",
     "@backstage/frontend-defaults": "^0.5.4",

--- a/src/alpha/entityCards.tsx
+++ b/src/alpha/entityCards.tsx
@@ -5,10 +5,10 @@ import { EntityCardBlueprint } from "@backstage/plugin-catalog-react/alpha";
 /** @alpha */
 export const rootlyOverviewEntityCard = EntityCardBlueprint.make({
   params: {
-    filter: "kind:component",
+    filter: { kind: "component" },
     loader: async () =>
       import("../components/Entity").then((m) =>
-        compatWrapper(<m.RootlyOverviewCard />)
+        compatWrapper(<m.RootlyOverviewCard />),
       ),
   },
 });

--- a/src/alpha/entityPageIntegration.test.tsx
+++ b/src/alpha/entityPageIntegration.test.tsx
@@ -1,0 +1,42 @@
+/** @jsxRuntime automatic */
+import type { Entity } from "@backstage/catalog-model";
+import { renderTestApp } from "@backstage/frontend-test-utils";
+import { createTestEntityPage } from "@backstage/plugin-catalog-react/testUtils";
+import { screen } from "@testing-library/react";
+
+import { rootlyOverviewEntityCard } from "./entityCards";
+
+const entity = (kind: string): Entity => ({
+  apiVersion: "backstage.io/v1alpha1",
+  kind,
+  metadata: { name: "payments" },
+});
+
+describe("Rootly entity-card integration", () => {
+  it("mounts the real card on a Backstage Component entity page", async () => {
+    renderTestApp({
+      extensions: [
+        createTestEntityPage({ entity: entity("Component") }),
+        rootlyOverviewEntityCard,
+      ],
+    });
+
+    expect(
+      await screen.findByText("No Rootly annotations found"),
+    ).toBeInTheDocument();
+  });
+
+  it("honors the extension filter for non-Component entities", async () => {
+    renderTestApp({
+      extensions: [
+        createTestEntityPage({ entity: entity("System") }),
+        rootlyOverviewEntityCard,
+      ],
+    });
+
+    expect(await screen.findByTestId("empty-entity-page")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No Rootly annotations found"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/alpha/extensions.test.tsx
+++ b/src/alpha/extensions.test.tsx
@@ -1,0 +1,91 @@
+/** @jsxRuntime automatic */
+import type { Entity } from "@backstage/catalog-model";
+import {
+  createExtensionTester,
+  renderInTestApp,
+} from "@backstage/frontend-test-utils";
+import { EntityCardBlueprint } from "@backstage/plugin-catalog-react/alpha";
+import { screen } from "@testing-library/react";
+
+import { rootlyOverviewEntityCard } from "./entityCards";
+import { rootlyIncidentsEntityContent } from "./entityContents";
+import { rootlyPage } from "./pages";
+
+jest.mock("../components/Entity", () => ({
+  RootlyOverviewCard: () => <div>Rootly overview extension</div>,
+}));
+jest.mock("../components/RootlyIncidentsPage", () => ({
+  RootlyIncidentsPage: () => <div>Rootly incidents extension</div>,
+}));
+jest.mock("../components/RootlyPage", () => ({
+  RootlyPage: () => <div>Rootly page extension</div>,
+}));
+
+const entity = (kind: string): Entity => ({
+  apiVersion: "backstage.io/v1alpha1",
+  kind,
+  metadata: { name: "example" },
+});
+
+describe("alpha frontend extensions", () => {
+  const originalWarn = console.warn;
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation((...args) => {
+        if (
+          typeof args[0] === "string" &&
+          args[0].startsWith(
+            "The following icons were registered as IconComponent",
+          )
+        ) {
+          return;
+        }
+        originalWarn.call(console, ...args);
+      });
+  });
+
+  afterAll(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("loads the Rootly page extension", async () => {
+    renderInTestApp(createExtensionTester(rootlyPage).reactElement());
+
+    expect(
+      await screen.findByText("Rootly page extension"),
+    ).toBeInTheDocument();
+  });
+
+  it("loads the overview-card extension", async () => {
+    renderInTestApp(
+      createExtensionTester(rootlyOverviewEntityCard).reactElement(),
+    );
+
+    expect(
+      await screen.findByText("Rootly overview extension"),
+    ).toBeInTheDocument();
+  });
+
+  it("filters the overview card to Component entities", () => {
+    const filter = createExtensionTester(rootlyOverviewEntityCard).get(
+      EntityCardBlueprint.dataRefs.filterFunction,
+    );
+
+    expect(filter?.(entity("Component"))).toBe(true);
+    expect(filter?.(entity("component"))).toBe(true);
+    expect(filter?.(entity("System"))).toBe(false);
+  });
+
+  it("loads the incidents entity-content extension", async () => {
+    renderInTestApp(
+      createExtensionTester(rootlyIncidentsEntityContent).reactElement(),
+    );
+
+    expect(
+      await screen.findByText("Rootly incidents extension"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/alpha/extensions.test.tsx
+++ b/src/alpha/extensions.test.tsx
@@ -28,29 +28,6 @@ const entity = (kind: string): Entity => ({
 });
 
 describe("alpha frontend extensions", () => {
-  const originalWarn = console.warn;
-  let consoleWarnSpy: jest.SpyInstance;
-
-  beforeAll(() => {
-    consoleWarnSpy = jest
-      .spyOn(console, "warn")
-      .mockImplementation((...args) => {
-        if (
-          typeof args[0] === "string" &&
-          args[0].startsWith(
-            "The following icons were registered as IconComponent",
-          )
-        ) {
-          return;
-        }
-        originalWarn.call(console, ...args);
-      });
-  });
-
-  afterAll(() => {
-    consoleWarnSpy.mockRestore();
-  });
-
   it("loads the Rootly page extension", async () => {
     renderInTestApp(createExtensionTester(rootlyPage).reactElement());
 

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,8 +1,15 @@
 import type { DiscoveryApi, IdentityApi } from "@backstage/core-plugin-api";
-import { mockApis } from "@backstage/frontend-test-utils";
+import { mockApis, renderInTestApp } from "@backstage/frontend-test-utils";
 import { RootlyApi } from "@rootly/backstage-plugin-common";
+import { screen } from "@testing-library/react";
+import { createElement } from "react";
 
-import { RootlyApiImpl } from "./api";
+import {
+  rootlyApiRef,
+  RootlyApiImpl,
+  type RootlyApiRef,
+  useRootlyClient,
+} from "./api";
 
 jest.mock("@rootly/backstage-plugin-common", () => ({
   ...jest.requireActual("@rootly/backstage-plugin-common"),
@@ -118,6 +125,32 @@ describe("RootlyApiImpl", () => {
       apiProxyUrl: proxyUrl,
       apiToken: credentials,
       apiHost: undefined,
+    });
+  });
+});
+
+describe("useRootlyClient", () => {
+  it("uses an application-provided Rootly API override", async () => {
+    const customClient = {} as RootlyApi;
+    const getClient = jest.fn().mockReturnValue(customClient);
+    const customApi: RootlyApiRef = { getClient };
+
+    const Probe = () => {
+      const client = useRootlyClient({ organizationId: "organization-id" });
+      return createElement(
+        "div",
+        null,
+        client === customClient ? "Custom client" : "Fallback client",
+      );
+    };
+
+    renderInTestApp(createElement(Probe), {
+      apis: [[rootlyApiRef, customApi]],
+    });
+
+    expect(await screen.findByText("Custom client")).toBeInTheDocument();
+    expect(getClient).toHaveBeenCalledWith({
+      organizationId: "organization-id",
     });
   });
 });

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,0 +1,123 @@
+import type { DiscoveryApi, IdentityApi } from "@backstage/core-plugin-api";
+import { mockApis } from "@backstage/frontend-test-utils";
+import { RootlyApi } from "@rootly/backstage-plugin-common";
+
+import { RootlyApiImpl } from "./api";
+
+jest.mock("@rootly/backstage-plugin-common", () => ({
+  ...jest.requireActual("@rootly/backstage-plugin-common"),
+  RootlyApi: jest.fn(),
+}));
+
+const MockedRootlyApi = jest.mocked(RootlyApi);
+const proxyUrl = Promise.resolve("https://backstage.example/api/proxy");
+const credentials = Promise.resolve({ token: "backstage-token" });
+
+const discovery = {
+  getBaseUrl: jest.fn().mockReturnValue(proxyUrl),
+} as unknown as DiscoveryApi;
+
+const identity = {
+  getCredentials: jest.fn().mockReturnValue(credentials),
+} as unknown as IdentityApi;
+
+const createApi = (rootly: Record<string, Record<string, string | boolean>>) =>
+  RootlyApiImpl.fromOptions({
+    config: mockApis.config({ data: { rootly } }),
+    discovery,
+    identity,
+  });
+
+describe("RootlyApiImpl", () => {
+  beforeEach(() => {
+    MockedRootlyApi.mockClear();
+  });
+
+  it("creates a client from the only configured organization", () => {
+    createApi({
+      primary: {
+        proxyPath: "/api/proxy/rootly",
+        apiHost: "https://rootly.example",
+      },
+    }).getClient({});
+
+    expect(MockedRootlyApi).toHaveBeenCalledWith({
+      apiProxyPath: "/api/proxy/rootly",
+      apiProxyUrl: proxyUrl,
+      apiToken: credentials,
+      apiHost: "https://rootly.example",
+    });
+  });
+
+  it("uses the explicitly requested organization", () => {
+    createApi({
+      first: {
+        proxyPath: "/api/proxy/first",
+        apiHost: "https://first.rootly.example",
+      },
+      second: {
+        proxyPath: "/api/proxy/second",
+        apiHost: "https://second.rootly.example",
+      },
+    }).getClient({ organizationId: "second" });
+
+    expect(MockedRootlyApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiProxyPath: "/api/proxy/second",
+        apiHost: "https://second.rootly.example",
+      }),
+    );
+  });
+
+  it("uses the default organization when none is requested", () => {
+    createApi({
+      first: {
+        proxyPath: "/api/proxy/first",
+        apiHost: "https://first.rootly.example",
+      },
+      second: {
+        isDefault: true,
+        proxyPath: "/api/proxy/second",
+        apiHost: "https://second.rootly.example",
+      },
+    }).getClient({});
+
+    expect(MockedRootlyApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiProxyPath: "/api/proxy/second",
+        apiHost: "https://second.rootly.example",
+      }),
+    );
+  });
+
+  it("falls back to the first organization when no default is configured", () => {
+    createApi({
+      first: {
+        proxyPath: "/api/proxy/first",
+        apiHost: "https://first.rootly.example",
+      },
+      second: {
+        proxyPath: "/api/proxy/second",
+        apiHost: "https://second.rootly.example",
+      },
+    }).getClient({});
+
+    expect(MockedRootlyApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiProxyPath: "/api/proxy/first",
+        apiHost: "https://first.rootly.example",
+      }),
+    );
+  });
+
+  it("passes undefined optional settings through to the common client", () => {
+    createApi({ primary: {} }).getClient({});
+
+    expect(MockedRootlyApi).toHaveBeenCalledWith({
+      apiProxyPath: undefined,
+      apiProxyUrl: proxyUrl,
+      apiToken: credentials,
+      apiHost: undefined,
+    });
+  });
+});

--- a/src/components/CatalogEntitiesTable/CatalogEntitiesTable.test.tsx
+++ b/src/components/CatalogEntitiesTable/CatalogEntitiesTable.test.tsx
@@ -1,0 +1,254 @@
+/** @jsxRuntime automatic */
+import type { RootlyCatalogEntity } from "@rootly/backstage-plugin-common";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+
+import { CatalogEntitiesTable } from "./CatalogEntitiesTable";
+
+const mockGetCatalogs = jest.fn();
+const mockGetCatalogEntities = jest.fn();
+const mockGetCatalogEntityDetailsURL = jest.fn();
+const mockUseRootlyClient = jest.fn();
+
+jest.mock("../../api", () => ({
+  useRootlyClient: (options: unknown) => mockUseRootlyClient(options),
+}));
+jest.mock("@material-ui/core", () => ({
+  FormControl: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  InputLabel: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+  makeStyles: () => () => ({ empty: "empty", searchContainer: "search" }),
+  MenuItem: ({ children, value }: { children: ReactNode; value: string }) => (
+    <option value={value}>{children}</option>
+  ),
+  Select: ({
+    children,
+    onChange,
+    value,
+  }: {
+    children: ReactNode;
+    onChange: (event: { target: { value: string } }) => void;
+    value: string;
+  }) => (
+    <select
+      aria-label="Catalog selector"
+      onChange={(event) => onChange({ target: { value: event.target.value } })}
+      value={value}
+    >
+      {children}
+    </select>
+  ),
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+jest.mock("@material-ui/core/Link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+jest.mock("@material-ui/lab", () => ({
+  Alert: ({ children }: { children: ReactNode }) => (
+    <div role="alert">{children}</div>
+  ),
+}));
+jest.mock("@backstage/plugin-catalog-react", () => ({
+  EntityRefLink: ({ entityRef }: { entityRef: { name: string } }) => (
+    <div>Backstage entity {entityRef.name}</div>
+  ),
+}));
+jest.mock("@backstage/plugin-search-react", () => ({
+  SearchBarBase: ({
+    onChange,
+    placeholder,
+    value,
+  }: {
+    onChange: (value: string) => void;
+    placeholder: string;
+    value: string;
+  }) => (
+    <input
+      aria-label={placeholder}
+      onChange={(event) => onChange(event.target.value)}
+      value={value}
+    />
+  ),
+}));
+jest.mock("@backstage/core-components", () => ({
+  Table: ({
+    columns,
+    data,
+    emptyContent,
+    onPageChange,
+    onRowsPerPageChange,
+  }: {
+    columns: Array<{
+      field: string;
+      render?: (row: RootlyCatalogEntity) => ReactNode;
+    }>;
+    data: RootlyCatalogEntity[];
+    emptyContent: ReactNode;
+    onPageChange: (page: number) => void;
+    onRowsPerPageChange: (size: number) => void;
+  }) => (
+    <div>
+      {data.length === 0 && emptyContent}
+      {data.map((row) => (
+        <div key={row.id}>
+          {columns.map((column) => (
+            <div key={column.field}>{column.render?.(row)}</div>
+          ))}
+        </div>
+      ))}
+      <button type="button" onClick={() => onPageChange(1)}>
+        Next page
+      </button>
+      <button type="button" onClick={() => onRowsPerPageChange(25)}>
+        Show 25
+      </button>
+    </div>
+  ),
+}));
+
+const catalogs = [
+  { id: "catalog-1", attributes: { name: "Primary", slug: "primary" } },
+  { id: "catalog-2", attributes: { name: "Secondary", slug: "secondary" } },
+];
+const catalogEntity = {
+  id: "entity-1",
+  type: "catalog_entities",
+  attributes: {
+    backstage_id: "component:default/payments",
+    created_at: "2026-01-01T00:00:00Z",
+    description: "Payment service",
+    name: "Payments",
+    updated_at: "2026-01-02T00:00:00Z",
+  },
+} as unknown as RootlyCatalogEntity;
+
+describe("CatalogEntitiesTable", () => {
+  beforeEach(() => {
+    mockGetCatalogs.mockReset().mockResolvedValue({ data: catalogs });
+    mockGetCatalogEntities.mockReset().mockResolvedValue({
+      data: [],
+      meta: { total_count: 0 },
+    });
+    mockGetCatalogEntityDetailsURL
+      .mockReset()
+      .mockReturnValue("https://rootly.example/catalog/entities/entity-1");
+    mockUseRootlyClient.mockReset().mockReturnValue({
+      getCatalogs: mockGetCatalogs,
+      getCatalogEntities: mockGetCatalogEntities,
+      getCatalogEntityDetailsURL: mockGetCatalogEntityDetailsURL,
+    });
+  });
+
+  it("loads the first catalog and its entities by default", async () => {
+    render(
+      <CatalogEntitiesTable
+        organizationId="organization-id"
+        params={{ filter: { kind: "Component" } }}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetCatalogEntities).toHaveBeenCalled());
+    expect(mockUseRootlyClient).toHaveBeenCalledWith({
+      organizationId: "organization-id",
+    });
+    expect(mockGetCatalogs).toHaveBeenCalledTimes(1);
+    expect(mockGetCatalogEntities).toHaveBeenLastCalledWith("catalog-1", {
+      filter: { kind: "Component", search: "" },
+      page: { number: 1, size: 10 },
+    });
+  });
+
+  it("renders Rootly and Backstage links with the active catalog slug", async () => {
+    mockGetCatalogEntities.mockResolvedValue({
+      data: [catalogEntity],
+      meta: { total_count: 1 },
+    });
+
+    render(<CatalogEntitiesTable />);
+
+    expect(await screen.findByText("Payments")).toHaveAttribute(
+      "href",
+      "https://rootly.example/catalog/entities/entity-1",
+    );
+    expect(mockGetCatalogEntityDetailsURL).toHaveBeenCalledWith(
+      catalogEntity,
+      "primary",
+    );
+    expect(screen.getByText("Backstage entity payments")).toBeInTheDocument();
+  });
+
+  it("switches catalogs and resets the page", async () => {
+    render(<CatalogEntitiesTable />);
+    await waitFor(() => expect(mockGetCatalogEntities).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+    await waitFor(() =>
+      expect(mockGetCatalogEntities).toHaveBeenLastCalledWith(
+        "catalog-1",
+        expect.objectContaining({ page: { number: 2, size: 10 } }),
+      ),
+    );
+
+    fireEvent.change(screen.getByLabelText("Catalog selector"), {
+      target: { value: "catalog-2" },
+    });
+    await waitFor(() =>
+      expect(mockGetCatalogEntities).toHaveBeenLastCalledWith(
+        "catalog-2",
+        expect.objectContaining({ page: { number: 1, size: 10 } }),
+      ),
+    );
+  });
+
+  it("does not request entities when no catalogs exist", async () => {
+    mockGetCatalogs.mockResolvedValue({ data: [] });
+
+    render(<CatalogEntitiesTable />);
+
+    expect(await screen.findByText("No catalog entities")).toBeInTheDocument();
+    expect(mockGetCatalogEntities).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["catalog", mockGetCatalogs],
+    ["entity", mockGetCatalogEntities],
+  ])("renders %s API failures", async (_type, api) => {
+    api.mockRejectedValue(new Error("Rootly unavailable"));
+
+    render(<CatalogEntitiesTable />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Rootly unavailable",
+    );
+  });
+
+  it("refetches for search and page-size changes", async () => {
+    const user = userEvent.setup();
+    render(<CatalogEntitiesTable />);
+    await waitFor(() => expect(mockGetCatalogEntities).toHaveBeenCalled());
+
+    await user.type(
+      screen.getByLabelText("Search Catalog Entities"),
+      "payments",
+    );
+    await waitFor(() =>
+      expect(mockGetCatalogEntities).toHaveBeenLastCalledWith("catalog-1", {
+        filter: { search: "payments" },
+        page: { number: 1, size: 10 },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show 25" }));
+    await waitFor(() =>
+      expect(mockGetCatalogEntities).toHaveBeenLastCalledWith("catalog-1", {
+        filter: { search: "payments" },
+        page: { number: 1, size: 25 },
+      }),
+    );
+  });
+});

--- a/src/components/EntitiesTable/EntitiesTable.test.tsx
+++ b/src/components/EntitiesTable/EntitiesTable.test.tsx
@@ -1,0 +1,185 @@
+/** @jsxRuntime automatic */
+import type { Entity } from "@backstage/catalog-model";
+import {
+  ROOTLY_ANNOTATION_CATALOG_ENTITY_ID,
+  ROOTLY_ANNOTATION_ORG_ID,
+} from "@rootly/backstage-plugin-common";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { EntitiesTable } from "./EntitiesTable";
+
+const mockGetEntities = jest.fn();
+const mockGetServices = jest.fn();
+const mockGetFunctionalities = jest.fn();
+const mockGetTeams = jest.fn();
+const mockGetCatalogEntity = jest.fn();
+const mockUseRootlyClient = jest.fn();
+
+jest.mock("@backstage/core-plugin-api", () => ({
+  useApi: () => ({ getEntities: mockGetEntities }),
+}));
+jest.mock("@backstage/plugin-catalog-react", () => ({
+  catalogApiRef: {},
+  EntityRefLink: ({ entityRef }: { entityRef: Entity }) => (
+    <div>Backstage entity {entityRef.metadata.name}</div>
+  ),
+}));
+jest.mock("../../api", () => ({
+  useRootlyClient: (options: unknown) => mockUseRootlyClient(options),
+}));
+jest.mock("@material-ui/core/Link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+jest.mock("@material-ui/lab", () => ({
+  Alert: ({ children }: { children: ReactNode }) => (
+    <div role="alert">{children}</div>
+  ),
+}));
+jest.mock("@backstage/core-components", () => ({
+  Progress: () => <div>Loading link</div>,
+  Table: ({
+    columns,
+    data,
+  }: {
+    columns: Array<{
+      field: string;
+      render?: (row: Entity) => ReactNode;
+    }>;
+    data: Entity[];
+  }) => (
+    <div>
+      {data.map((row) => (
+        <div key={row.metadata.name}>
+          {columns.map((column, index) => (
+            <div key={`${column.field}-${index}`}>{column.render?.(row)}</div>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+const entity = (annotations: Record<string, string> = {}): Entity => ({
+  apiVersion: "backstage.io/v1alpha1",
+  kind: "Component",
+  metadata: {
+    annotations,
+    name: "payments",
+    namespace: "default",
+  },
+});
+
+const resource = (name: string) => ({
+  id: `${name.toLowerCase()}-id`,
+  attributes: { name },
+});
+
+describe("EntitiesTable", () => {
+  beforeEach(() => {
+    mockGetEntities.mockReset().mockResolvedValue({ items: [] });
+    mockGetServices.mockReset().mockResolvedValue({ data: [] });
+    mockGetFunctionalities.mockReset().mockResolvedValue({ data: [] });
+    mockGetTeams.mockReset().mockResolvedValue({ data: [] });
+    mockGetCatalogEntity.mockReset().mockResolvedValue(undefined);
+    mockUseRootlyClient.mockReset().mockReturnValue({
+      getCatalogEntity: mockGetCatalogEntity,
+      getCatalogEntityDetailsURL: () => "https://rootly/catalog-entity",
+      getFunctionalities: mockGetFunctionalities,
+      getFunctionalityDetailsURL: () => "https://rootly/functionality",
+      getServices: mockGetServices,
+      getServiceDetailsURL: () => "https://rootly/service",
+      getTeams: mockGetTeams,
+      getTeamDetailsURL: () => "https://rootly/team",
+    });
+  });
+
+  it("looks up all Rootly resource types using the Backstage entity ref", async () => {
+    mockGetEntities.mockResolvedValue({
+      items: [
+        entity({
+          [ROOTLY_ANNOTATION_ORG_ID]: "organization-id",
+          [ROOTLY_ANNOTATION_CATALOG_ENTITY_ID]: "catalog-entity-id",
+        }),
+      ],
+    });
+    mockGetServices.mockResolvedValue({ data: [resource("Service")] });
+    mockGetFunctionalities.mockResolvedValue({
+      data: [resource("Functionality")],
+    });
+    mockGetTeams.mockResolvedValue({ data: [resource("Team")] });
+    mockGetCatalogEntity.mockResolvedValue({
+      data: resource("Catalog Entity"),
+      included: [{ type: "catalogs", attributes: { slug: "main-catalog" } }],
+    });
+
+    render(<EntitiesTable />);
+
+    expect(await screen.findByText("Service")).toHaveAttribute(
+      "href",
+      "https://rootly/service",
+    );
+    expect(screen.getByText("Functionality")).toHaveAttribute(
+      "href",
+      "https://rootly/functionality",
+    );
+    expect(screen.getByText("Team")).toHaveAttribute(
+      "href",
+      "https://rootly/team",
+    );
+    expect(screen.getByText("Catalog Entity")).toHaveAttribute(
+      "href",
+      "https://rootly/catalog-entity",
+    );
+    expect(mockUseRootlyClient).toHaveBeenCalledWith({
+      organizationId: "organization-id",
+    });
+    const expectedFilter = {
+      filter: { backstage_id: "component:default/payments" },
+    };
+    expect(mockGetServices).toHaveBeenCalledWith(expectedFilter);
+    expect(mockGetFunctionalities).toHaveBeenCalledWith(expectedFilter);
+    expect(mockGetTeams).toHaveBeenCalledWith(expectedFilter);
+    expect(mockGetCatalogEntity).toHaveBeenCalledWith("catalog-entity-id", {
+      include: "catalog",
+    });
+  });
+
+  it("renders unlinked states and skips catalog lookup without an annotation", async () => {
+    mockGetEntities.mockResolvedValue({ items: [entity()] });
+
+    render(<EntitiesTable />);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Not Linked")).toHaveLength(3),
+    );
+    expect(screen.getByText("-")).toBeInTheDocument();
+    expect(mockGetCatalogEntity).not.toHaveBeenCalled();
+  });
+
+  it("renders individual Rootly lookup failures without failing the table", async () => {
+    mockGetEntities.mockResolvedValue({ items: [entity()] });
+    mockGetServices.mockRejectedValue(new Error("service unavailable"));
+    mockGetFunctionalities.mockRejectedValue(
+      new Error("functionality unavailable"),
+    );
+    mockGetTeams.mockRejectedValue(new Error("team unavailable"));
+
+    render(<EntitiesTable />);
+
+    await waitFor(() => expect(screen.getAllByText("Error")).toHaveLength(3));
+  });
+
+  it("renders Backstage catalog API failures", async () => {
+    mockGetEntities.mockRejectedValue(new Error("Catalog unavailable"));
+
+    render(<EntitiesTable />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Catalog unavailable",
+    );
+  });
+});

--- a/src/components/Entity/RootlyOverviewCard.test.tsx
+++ b/src/components/Entity/RootlyOverviewCard.test.tsx
@@ -1,0 +1,96 @@
+/** @jsxRuntime automatic */
+import type { Entity } from "@backstage/catalog-model";
+import {
+  ROOTLY_ANNOTATION_CATALOG_ENTITY_ID,
+  ROOTLY_ANNOTATION_CATALOG_ENTITY_SLUG,
+  ROOTLY_ANNOTATION_FUNCTIONALITY_ID,
+  ROOTLY_ANNOTATION_FUNCTIONALITY_SLUG,
+  ROOTLY_ANNOTATION_SERVICE_ID,
+  ROOTLY_ANNOTATION_SERVICE_SLUG,
+  ROOTLY_ANNOTATION_TEAM_ID,
+  ROOTLY_ANNOTATION_TEAM_SLUG,
+} from "@rootly/backstage-plugin-common";
+import { render, screen } from "@testing-library/react";
+
+import { RootlyOverviewCard } from "./RootlyOverviewCard";
+
+const mockUseEntity = jest.fn();
+
+jest.mock("@backstage/plugin-catalog-react", () => ({
+  ...jest.requireActual("@backstage/plugin-catalog-react"),
+  useEntity: () => mockUseEntity(),
+}));
+
+jest.mock("./RootlyOverviewServiceCard", () => ({
+  RootlyOverviewServiceCard: () => <div>service overview</div>,
+}));
+jest.mock("./RootlyOverviewFunctionalityCard", () => ({
+  RootlyOverviewFunctionalityCard: () => <div>functionality overview</div>,
+}));
+jest.mock("./RootlyOverviewTeamCard", () => ({
+  RootlyOverviewTeamCard: () => <div>team overview</div>,
+}));
+jest.mock("./RootlyOverviewCatalogEntityCard", () => ({
+  RootlyOverviewCatalogEntityCard: () => <div>catalog entity overview</div>,
+}));
+
+const entityWithAnnotations = (
+  annotations?: Record<string, string>,
+): Entity => ({
+  apiVersion: "backstage.io/v1alpha1",
+  kind: "Component",
+  metadata: { annotations, name: "example" },
+});
+
+const cases = [
+  [ROOTLY_ANNOTATION_SERVICE_ID, "service overview"],
+  [ROOTLY_ANNOTATION_SERVICE_SLUG, "service overview"],
+  [ROOTLY_ANNOTATION_FUNCTIONALITY_ID, "functionality overview"],
+  [ROOTLY_ANNOTATION_FUNCTIONALITY_SLUG, "functionality overview"],
+  [ROOTLY_ANNOTATION_TEAM_ID, "team overview"],
+  [ROOTLY_ANNOTATION_TEAM_SLUG, "team overview"],
+  [ROOTLY_ANNOTATION_CATALOG_ENTITY_ID, "catalog entity overview"],
+  [ROOTLY_ANNOTATION_CATALOG_ENTITY_SLUG, "catalog entity overview"],
+] as const;
+
+describe("RootlyOverviewCard", () => {
+  it.each(cases)("renders the matching card for %s", (annotation, expected) => {
+    mockUseEntity.mockReturnValue({
+      entity: entityWithAnnotations({ [annotation]: "rootly-id" }),
+    });
+
+    render(<RootlyOverviewCard />);
+
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it("uses service, functionality, team, then catalog precedence", () => {
+    mockUseEntity.mockReturnValue({
+      entity: entityWithAnnotations({
+        [ROOTLY_ANNOTATION_CATALOG_ENTITY_ID]: "catalog",
+        [ROOTLY_ANNOTATION_FUNCTIONALITY_ID]: "functionality",
+        [ROOTLY_ANNOTATION_SERVICE_ID]: "service",
+        [ROOTLY_ANNOTATION_TEAM_ID]: "team",
+      }),
+    });
+
+    render(<RootlyOverviewCard />);
+
+    expect(screen.getByText("service overview")).toBeInTheDocument();
+    expect(
+      screen.queryByText("functionality overview"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("team overview")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("catalog entity overview"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a useful fallback without Rootly annotations", () => {
+    mockUseEntity.mockReturnValue({ entity: entityWithAnnotations() });
+
+    render(<RootlyOverviewCard />);
+
+    expect(screen.getByText("No Rootly annotations found")).toBeInTheDocument();
+  });
+});

--- a/src/components/Entity/RootlyOverviewFunctionalityCard.tsx
+++ b/src/components/Entity/RootlyOverviewFunctionalityCard.tsx
@@ -149,7 +149,7 @@ export const RootlyOverviewFunctionalityCard = () => {
     [functionality]
   );
 
-  const incidents = incidentsResponse && incidentsResponse.data && incidentsResponse.data.length > 0 ? incidentsResponse.data : null;
+  const incidents = incidentsResponse?.data ?? null;
 
   return (
     <Card>
@@ -194,12 +194,13 @@ export const RootlyOverviewFunctionalityCard = () => {
         {incidentsError && <Alert severity="error">{incidentsError.message}</Alert>}
         {!incidentsLoading && !incidentsError && !incidentsLoading && incidents && (
           <>
-            {incidents && incidents.length >= 0 && (
+            {incidents.length > 0 ? (
               <Typography variant="subtitle1">
                 There is <strong>{incidents.length}</strong> ongoing incidents for this functionality
               </Typography>
+            ) : (
+              <Typography variant="subtitle1">No ongoing incidents</Typography>
             )}
-            {incidents && incidents.length === 0 && <Typography variant="subtitle1">No ongoing incidents</Typography>}
             <List dense>
               {incidents &&
                 incidents.map((incident: RootlyIncident) => <IncidentListItem incident={incident} rootlyClient={rootlyClient} />)}

--- a/src/components/Entity/RootlyOverviewResourceCards.test.tsx
+++ b/src/components/Entity/RootlyOverviewResourceCards.test.tsx
@@ -1,0 +1,316 @@
+/** @jsxRuntime automatic */
+import type { Entity } from "@backstage/catalog-model";
+import {
+  ROOTLY_ANNOTATION_CATALOG_ENTITY_ID,
+  ROOTLY_ANNOTATION_ORG_ID,
+} from "@rootly/backstage-plugin-common";
+import { render, screen } from "@testing-library/react";
+import type { ComponentType, ReactNode } from "react";
+
+import { RootlyOverviewCatalogEntityCard } from "./RootlyOverviewCatalogEntityCard";
+import { RootlyOverviewFunctionalityCard } from "./RootlyOverviewFunctionalityCard";
+import { RootlyOverviewServiceCard } from "./RootlyOverviewServiceCard";
+import { RootlyOverviewTeamCard } from "./RootlyOverviewTeamCard";
+
+const mockUseEntity = jest.fn();
+const mockUseRootlyClient = jest.fn();
+const mockGetServices = jest.fn();
+const mockGetFunctionalities = jest.fn();
+const mockGetTeams = jest.fn();
+const mockGetIncidents = jest.fn();
+const mockGetServiceIncidentsChart = jest.fn();
+const mockGetFunctionalityIncidentsChart = jest.fn();
+const mockGetTeamIncidentsChart = jest.fn();
+const mockGetCatalogEntity = jest.fn();
+const mockGetCatalogEntityDetailsURL = jest.fn();
+
+jest.mock("@backstage/plugin-catalog-react", () => ({
+  useEntity: () => mockUseEntity(),
+}));
+jest.mock("../../api", () => ({
+  useRootlyClient: (options: unknown) => mockUseRootlyClient(options),
+}));
+jest.mock("react-chartkick", () => ({
+  LineChart: ({ data }: { data: unknown }) => (
+    <div data-testid="incident-chart">{JSON.stringify(data)}</div>
+  ),
+}));
+jest.mock("chartkick/chart.js", () => ({}));
+jest.mock("../UI/ColoredChip", () => ({
+  ColoredChip: ({ label }: { label?: string }) => <span>{label}</span>,
+}));
+jest.mock("../UI/StatusChip", () => ({
+  StatusChip: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+jest.mock("@backstage/core-components", () => ({
+  HeaderIconLinkRow: ({
+    links,
+  }: {
+    links: Array<{ href: string; label: string }>;
+  }) => (
+    <div>
+      {links.map((link) => (
+        <a href={link.href} key={link.label}>
+          {link.label}
+        </a>
+      ))}
+    </div>
+  ),
+  Progress: () => <div>Loading Rootly data</div>,
+}));
+jest.mock("@material-ui/core", () => ({
+  Card: ({ children }: { children: ReactNode }) => (
+    <section>{children}</section>
+  ),
+  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CardHeader: ({
+    action,
+    subheader,
+    title,
+  }: {
+    action: ReactNode;
+    subheader: ReactNode;
+    title: ReactNode;
+  }) => (
+    <header>
+      {title}
+      {action}
+      {subheader}
+    </header>
+  ),
+  Divider: () => <hr />,
+  IconButton: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick: () => void;
+  }) => (
+    <button type="button" aria-label="Refresh" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  List: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ListItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ListItemSecondaryAction: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ListItemText: ({
+    primary,
+    secondary,
+  }: {
+    primary: ReactNode;
+    secondary: ReactNode;
+  }) => (
+    <div>
+      {primary}
+      {secondary}
+    </div>
+  ),
+  Typography: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+jest.mock("@material-ui/core/Link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+jest.mock("@material-ui/lab", () => ({
+  Alert: ({ children }: { children: ReactNode }) => (
+    <div role="alert">{children}</div>
+  ),
+}));
+jest.mock("@material-ui/icons/FilterList", () => () => <span />);
+jest.mock("@material-ui/icons/Cached", () => () => <span />);
+jest.mock("@material-ui/icons/Whatshot", () => () => <span />);
+
+const entity = (annotations: Record<string, string> = {}): Entity => ({
+  apiVersion: "backstage.io/v1alpha1",
+  kind: "Component",
+  metadata: {
+    annotations: {
+      [ROOTLY_ANNOTATION_ORG_ID]: "organization-id",
+      ...annotations,
+    },
+    name: "payments",
+    namespace: "default",
+  },
+});
+
+const client = {
+  getCatalogEntity: mockGetCatalogEntity,
+  getCatalogEntityDetailsURL: mockGetCatalogEntityDetailsURL,
+  getCreateIncidentURL: () => "https://rootly.example/incidents/new",
+  getFunctionalities: mockGetFunctionalities,
+  getFunctionalityIncidentsChart: mockGetFunctionalityIncidentsChart,
+  getIncidents: mockGetIncidents,
+  getListIncidents: () => "https://rootly.example/incidents",
+  getListIncidentsForFunctionalityURL: () =>
+    "https://rootly.example/incidents/functionality",
+  getListIncidentsForServiceURL: () =>
+    "https://rootly.example/incidents/service",
+  getListIncidentsForTeamURL: () => "https://rootly.example/incidents/team",
+  getServiceIncidentsChart: mockGetServiceIncidentsChart,
+  getServices: mockGetServices,
+  getTeamIncidentsChart: mockGetTeamIncidentsChart,
+  getTeams: mockGetTeams,
+};
+
+const cases: Array<{
+  chart: jest.Mock;
+  component: ComponentType;
+  filter: string;
+  primary: jest.Mock;
+  type: "service" | "functionality" | "team";
+}> = [
+  {
+    chart: mockGetServiceIncidentsChart,
+    component: RootlyOverviewServiceCard,
+    filter: "services",
+    primary: mockGetServices,
+    type: "service",
+  },
+  {
+    chart: mockGetFunctionalityIncidentsChart,
+    component: RootlyOverviewFunctionalityCard,
+    filter: "functionalities",
+    primary: mockGetFunctionalities,
+    type: "functionality",
+  },
+  {
+    chart: mockGetTeamIncidentsChart,
+    component: RootlyOverviewTeamCard,
+    filter: "teams",
+    primary: mockGetTeams,
+    type: "team",
+  },
+];
+
+describe.each(cases)("Rootly $type overview card", (testCase) => {
+  const CardComponent = testCase.component;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseEntity.mockReturnValue({ entity: entity() });
+    mockUseRootlyClient.mockReturnValue(client);
+    mockGetIncidents.mockResolvedValue({ data: [] });
+    mockGetServiceIncidentsChart.mockResolvedValue({ data: [["day", 1]] });
+    mockGetFunctionalityIncidentsChart.mockResolvedValue({
+      data: [["day", 1]],
+    });
+    mockGetTeamIncidentsChart.mockResolvedValue({ data: [["day", 1]] });
+    testCase.primary.mockResolvedValue({
+      data: [
+        {
+          id: `${testCase.type}-id`,
+          attributes: { name: "Payments", slug: "payments" },
+        },
+      ],
+    });
+  });
+
+  it("loads the annotated organization, resource, incidents, and chart", async () => {
+    render(<CardComponent />);
+
+    expect(await screen.findByText("No ongoing incidents")).toBeInTheDocument();
+    expect(mockUseRootlyClient).toHaveBeenCalledWith({
+      organizationId: "organization-id",
+    });
+    expect(testCase.primary).toHaveBeenCalledWith({
+      filter: { backstage_id: "component:default/payments" },
+    });
+    expect(mockGetIncidents).toHaveBeenCalledWith({
+      filter: {
+        [testCase.filter]: "payments",
+        status: "started,mitigated",
+      },
+    });
+    expect(testCase.chart).toHaveBeenCalledWith(
+      expect.objectContaining({ id: `${testCase.type}-id` }),
+      { period: "day" },
+    );
+    expect(screen.getByTestId("incident-chart")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Create Incident" }),
+    ).toHaveAttribute("href", "https://rootly.example/incidents/new");
+  });
+
+  it("renders resource lookup failures", async () => {
+    testCase.primary.mockRejectedValue(new Error("Rootly unavailable"));
+
+    render(<CardComponent />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Rootly unavailable",
+    );
+  });
+});
+
+describe("Rootly catalog-entity overview card", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRootlyClient.mockReturnValue(client);
+    mockGetCatalogEntityDetailsURL.mockReturnValue(
+      "https://rootly.example/catalog/entity",
+    );
+  });
+
+  it("renders catalog details, properties, and the Rootly link", async () => {
+    mockUseEntity.mockReturnValue({
+      entity: entity({
+        [ROOTLY_ANNOTATION_CATALOG_ENTITY_ID]: "catalog-entity-id",
+      }),
+    });
+    const catalogEntity = {
+      id: "catalog-entity-id",
+      attributes: {
+        description: "Payment service",
+        name: "Payments Catalog Entry",
+        properties: [{ catalog_property_id: "tier", value: "critical" }],
+      },
+    };
+    mockGetCatalogEntity.mockResolvedValue({
+      data: catalogEntity,
+      included: [{ type: "catalogs", attributes: { slug: "service-catalog" } }],
+    });
+
+    render(<RootlyOverviewCatalogEntityCard />);
+
+    expect(
+      await screen.findByText("Payments Catalog Entry"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Payment service")).toBeInTheDocument();
+    expect(screen.getByText(/critical/)).toBeInTheDocument();
+    expect(mockGetCatalogEntity).toHaveBeenCalledWith("catalog-entity-id", {
+      include: "catalog",
+    });
+    expect(mockGetCatalogEntityDetailsURL).toHaveBeenCalledWith(
+      catalogEntity,
+      "service-catalog",
+    );
+    expect(
+      screen.getByRole("link", { name: "View in Rootly" }),
+    ).toHaveAttribute("href", "https://rootly.example/catalog/entity");
+  });
+
+  it("renders missing and failed catalog entities", async () => {
+    mockUseEntity.mockReturnValue({ entity: entity() });
+    const { unmount } = render(<RootlyOverviewCatalogEntityCard />);
+    expect(
+      await screen.findByText("Catalog entity not found in Rootly"),
+    ).toBeInTheDocument();
+    expect(mockGetCatalogEntity).not.toHaveBeenCalled();
+    unmount();
+
+    mockUseEntity.mockReturnValue({
+      entity: entity({
+        [ROOTLY_ANNOTATION_CATALOG_ENTITY_ID]: "catalog-entity-id",
+      }),
+    });
+    mockGetCatalogEntity.mockRejectedValue(new Error("Rootly unavailable"));
+    render(<RootlyOverviewCatalogEntityCard />);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Rootly unavailable",
+    );
+  });
+});

--- a/src/components/Entity/RootlyOverviewServiceCard.tsx
+++ b/src/components/Entity/RootlyOverviewServiceCard.tsx
@@ -164,7 +164,7 @@ export const RootlyOverviewServiceCard = () => {
     [service]
   );
 
-  const incidents = incidentsResponse && incidentsResponse.data && incidentsResponse.data.length > 0 ? incidentsResponse.data : null;
+  const incidents = incidentsResponse?.data ?? null;
 
   return (
     <Card>
@@ -209,12 +209,13 @@ export const RootlyOverviewServiceCard = () => {
         {incidentsError && <Alert severity="error">{incidentsError.message}</Alert>}
         {!incidentsLoading && !incidentsError && !incidentsLoading && incidents && (
           <>
-            {incidents && incidents.length >= 0 && (
+            {incidents.length > 0 ? (
               <Typography variant="subtitle1">
                 There is <strong>{incidents.length}</strong> ongoing incidents for this service
               </Typography>
+            ) : (
+              <Typography variant="subtitle1">No ongoing incidents</Typography>
             )}
-            {incidents && incidents.length === 0 && <Typography variant="subtitle1">No ongoing incidents</Typography>}
             <List dense>
               {incidents &&
                 incidents.map((incident: RootlyIncident) => <IncidentListItem incident={incident} rootlyClient={rootlyClient} />)}

--- a/src/components/Entity/RootlyOverviewTeamCard.tsx
+++ b/src/components/Entity/RootlyOverviewTeamCard.tsx
@@ -148,7 +148,7 @@ export const RootlyOverviewTeamCard = () => {
     [team]
   );
 
-  const incidents = incidentsResponse && incidentsResponse.data && incidentsResponse.data.length > 0 ? incidentsResponse.data : null;
+  const incidents = incidentsResponse?.data ?? null;
 
   return (
     <Card>
@@ -193,12 +193,13 @@ export const RootlyOverviewTeamCard = () => {
         {incidentsError && <Alert severity="error">{incidentsError.message}</Alert>}
         {!incidentsLoading && !incidentsError && !incidentsLoading && incidents && (
           <>
-            {incidents && incidents.length >= 0 && (
+            {incidents.length > 0 ? (
               <Typography variant="subtitle1">
                 There is <strong>{incidents.length}</strong> ongoing incidents for this team
               </Typography>
+            ) : (
+              <Typography variant="subtitle1">No ongoing incidents</Typography>
             )}
-            {incidents && incidents.length === 0 && <Typography variant="subtitle1">No ongoing incidents</Typography>}
             <List dense>
               {incidents &&
                 incidents.map((incident: RootlyIncident) => <IncidentListItem incident={incident} rootlyClient={rootlyClient} />)}

--- a/src/components/Incident/IncidentWrapper.test.ts
+++ b/src/components/Incident/IncidentWrapper.test.ts
@@ -1,0 +1,59 @@
+import type { RootlyIncident } from "@rootly/backstage-plugin-common";
+
+import { IncidentWrapper } from ".";
+
+const relationships = {
+  environments: { data: [{ id: "environment-1" }] },
+  services: { data: [{ id: "service-1" }] },
+  functionalities: { data: [{ id: "functionality-1" }] },
+  groups: { data: [{ id: "group-1" }] },
+  incident_types: { data: [{ id: "type-1" }] },
+};
+
+const incident = { relationships } as unknown as RootlyIncident;
+const included = [
+  { id: "environment-1", type: "environments" },
+  { id: "service-1", type: "services" },
+  { id: "functionality-1", type: "functionalities" },
+  { id: "group-1", type: "groups" },
+  { id: "type-1", type: "incident_types" },
+  { id: "service-1", type: "groups" },
+  { id: "unrelated", type: "services" },
+];
+
+describe("IncidentWrapper", () => {
+  it.each([
+    ["environments", "environments", "environment-1"],
+    ["services", "services", "service-1"],
+    ["functionalities", "functionalities", "functionality-1"],
+    ["groups", "groups", "group-1"],
+    ["types", "incident_types", "type-1"],
+  ] as const)(
+    "resolves the %s relationship from included resources",
+    (method, type, id) => {
+      const wrapper = new IncidentWrapper(incident, included);
+
+      expect(wrapper[method]()).toEqual([{ id, type }]);
+    },
+  );
+
+  it("returns empty arrays when relationships are absent", () => {
+    const wrapper = new IncidentWrapper({} as RootlyIncident, included);
+
+    expect(wrapper.environments()).toEqual([]);
+    expect(wrapper.services()).toEqual([]);
+    expect(wrapper.functionalities()).toEqual([]);
+    expect(wrapper.groups()).toEqual([]);
+    expect(wrapper.types()).toEqual([]);
+  });
+
+  it("returns empty arrays when included resources are absent", () => {
+    const wrapper = new IncidentWrapper(incident, undefined);
+
+    expect(wrapper.environments()).toEqual([]);
+    expect(wrapper.services()).toEqual([]);
+    expect(wrapper.functionalities()).toEqual([]);
+    expect(wrapper.groups()).toEqual([]);
+    expect(wrapper.types()).toEqual([]);
+  });
+});

--- a/src/components/Incident/index.ts
+++ b/src/components/Incident/index.ts
@@ -15,7 +15,7 @@ export class IncidentWrapper {
       });
       return this.included?.filter((i: { type: string; id: string }) => {
         return i.type === 'environments' && ids.includes(i.id);
-      });
+      }) ?? [];
     } 
       return [];
     
@@ -28,7 +28,7 @@ export class IncidentWrapper {
       });
       return this.included?.filter((i: { type: string; id: string }) => {
         return i.type === 'services' && ids.includes(i.id);
-      });
+      }) ?? [];
     } 
       return [];
     
@@ -41,7 +41,7 @@ export class IncidentWrapper {
       });
       return this.included?.filter((i: { type: string; id: string }) => {
         return i.type === 'functionalities' && ids.includes(i.id);
-      });
+      }) ?? [];
     } 
       return [];
     
@@ -54,7 +54,7 @@ export class IncidentWrapper {
       });
       return this.included?.filter((i: { type: string; id: string }) => {
         return i.type === 'groups' && ids.includes(i.id);
-      });
+      }) ?? [];
     } 
       return [];
     
@@ -67,7 +67,7 @@ export class IncidentWrapper {
       });
       return this.included?.filter((i: { type: string; id: string }) => {
         return i.type === 'incident_types' && ids.includes(i.id);
-      });
+      }) ?? [];
     } 
       return [];
     

--- a/src/components/IncidentsTable/IncidentsTable.test.tsx
+++ b/src/components/IncidentsTable/IncidentsTable.test.tsx
@@ -1,0 +1,232 @@
+/** @jsxRuntime automatic */
+import type { RootlyIncident } from "@rootly/backstage-plugin-common";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+
+import { IncidentsTable } from "./IncidentsTable";
+
+const mockGetIncidents = jest.fn();
+const mockUseRootlyClient = jest.fn();
+
+jest.mock("../../api", () => ({
+  useRootlyClient: (options: unknown) => mockUseRootlyClient(options),
+}));
+jest.mock("../UI/ColoredChip", () => ({
+  ColoredChip: ({ label }: { label?: string }) => <div>{label}</div>,
+}));
+jest.mock("../UI/ColoredChips", () => ({
+  ColoredChips: ({
+    objects,
+  }: {
+    objects: Array<{ attributes: { name: string } }>;
+  }) => <div>{objects.map((object) => object.attributes.name).join(", ")}</div>,
+}));
+jest.mock("../UI/StatusChip", () => ({
+  StatusChip: ({ status }: { status: string }) => <div>{status}</div>,
+}));
+jest.mock("@material-ui/core", () => ({
+  Chip: ({ label }: { label?: string }) => <div>{label}</div>,
+  makeStyles: () => () => ({ empty: "empty", searchContainer: "search" }),
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+jest.mock("@material-ui/core/Link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+jest.mock("@material-ui/lab", () => ({
+  Alert: ({ children }: { children: ReactNode }) => (
+    <div role="alert">{children}</div>
+  ),
+}));
+jest.mock("@backstage/plugin-search-react", () => ({
+  SearchBarBase: ({
+    onChange,
+    placeholder,
+    value,
+  }: {
+    onChange: (value: string) => void;
+    placeholder: string;
+    value: string;
+  }) => (
+    <input
+      aria-label={placeholder}
+      onChange={(event) => onChange(event.target.value)}
+      value={value}
+    />
+  ),
+}));
+jest.mock("@backstage/core-components", () => ({
+  Table: ({
+    columns,
+    data,
+    emptyContent,
+    onPageChange,
+    onRowsPerPageChange,
+  }: {
+    columns: Array<{
+      field: string;
+      render?: (row: unknown) => ReactNode;
+    }>;
+    data: unknown[];
+    emptyContent: ReactNode;
+    onPageChange: (page: number) => void;
+    onRowsPerPageChange: (size: number) => void;
+  }) => (
+    <div>
+      {data.length === 0 && emptyContent}
+      {data.map((row, rowIndex) => (
+        <div key={rowIndex}>
+          {columns.map((column) => (
+            <div key={column.field}>{column.render?.(row)}</div>
+          ))}
+        </div>
+      ))}
+      <button type="button" onClick={() => onPageChange(1)}>
+        Next page
+      </button>
+      <button type="button" onClick={() => onRowsPerPageChange(25)}>
+        Show 25
+      </button>
+    </div>
+  ),
+}));
+
+const incident = {
+  id: "incident-1",
+  type: "incidents",
+  attributes: {
+    created_at: "2026-01-01T00:00:00Z",
+    started_at: "2026-01-01T00:00:00Z",
+    status: "started",
+    summary: "Payment processing is degraded",
+    title: "Payments degraded",
+    url: "https://rootly.example/incidents/incident-1",
+    user: { data: { attributes: { full_name: "Ada Lovelace" } } },
+    severity: {
+      data: {
+        attributes: {
+          color: "#ff0000",
+          description: "Major incident",
+          name: "SEV-1",
+        },
+      },
+    },
+  },
+  relationships: {
+    environments: { data: [{ id: "environment-1" }] },
+    services: { data: [{ id: "service-1" }] },
+    functionalities: { data: [{ id: "functionality-1" }] },
+    groups: { data: [{ id: "group-1" }] },
+  },
+} as unknown as RootlyIncident;
+
+const included = [
+  {
+    id: "environment-1",
+    type: "environments",
+    attributes: { name: "Production" },
+  },
+  { id: "service-1", type: "services", attributes: { name: "Payments" } },
+  {
+    id: "functionality-1",
+    type: "functionalities",
+    attributes: { name: "Checkout" },
+  },
+  { id: "group-1", type: "groups", attributes: { name: "Reliability" } },
+];
+
+const response = (data: RootlyIncident[]) => ({
+  data,
+  included,
+  meta: { total_count: data.length },
+});
+
+describe("IncidentsTable", () => {
+  beforeEach(() => {
+    mockGetIncidents.mockReset().mockResolvedValue(response([]));
+    mockUseRootlyClient.mockReset().mockReturnValue({
+      getIncidents: mockGetIncidents,
+    });
+  });
+
+  it("passes organization, filters, and pagination to Rootly", async () => {
+    render(
+      <IncidentsTable
+        organizationId="organization-id"
+        params={{ filter: { status: "started" } }}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetIncidents).toHaveBeenCalled());
+    expect(mockUseRootlyClient).toHaveBeenCalledWith({
+      organizationId: "organization-id",
+    });
+    expect(mockGetIncidents).toHaveBeenLastCalledWith({
+      filter: { search: "", status: "started" },
+      page: { number: 1, size: 10 },
+    });
+  });
+
+  it("renders incident details and included relationships", async () => {
+    mockGetIncidents.mockResolvedValue(response([incident]));
+
+    render(<IncidentsTable />);
+
+    expect(await screen.findByText("Payments degraded")).toHaveAttribute(
+      "href",
+      "https://rootly.example/incidents/incident-1",
+    );
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByText("started")).toBeInTheDocument();
+    expect(screen.getByText("SEV-1")).toBeInTheDocument();
+    expect(screen.getByText("Production")).toBeInTheDocument();
+    expect(screen.getByText("Payments")).toBeInTheDocument();
+    expect(screen.getByText("Checkout")).toBeInTheDocument();
+    expect(screen.getByText("Reliability")).toBeInTheDocument();
+  });
+
+  it("renders empty and error states", async () => {
+    const { unmount } = render(<IncidentsTable />);
+    expect(await screen.findByText("No incidents")).toBeInTheDocument();
+    unmount();
+
+    mockGetIncidents.mockRejectedValue(new Error("Rootly unavailable"));
+    render(<IncidentsTable />);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Rootly unavailable",
+    );
+  });
+
+  it("refetches for search and pagination", async () => {
+    const user = userEvent.setup();
+    render(<IncidentsTable />);
+    await waitFor(() => expect(mockGetIncidents).toHaveBeenCalledTimes(1));
+
+    await user.type(screen.getByLabelText("Search Incidents"), "payments");
+    await waitFor(() =>
+      expect(mockGetIncidents).toHaveBeenLastCalledWith({
+        filter: { search: "payments" },
+        page: { number: 1, size: 10 },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+    await waitFor(() =>
+      expect(mockGetIncidents).toHaveBeenLastCalledWith({
+        filter: { search: "payments" },
+        page: { number: 2, size: 10 },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show 25" }));
+    await waitFor(() =>
+      expect(mockGetIncidents).toHaveBeenLastCalledWith({
+        filter: { search: "payments" },
+        page: { number: 2, size: 25 },
+      }),
+    );
+  });
+});

--- a/src/components/PageOutlets.test.tsx
+++ b/src/components/PageOutlets.test.tsx
@@ -1,0 +1,53 @@
+/** @jsxRuntime automatic */
+import { render, screen } from "@testing-library/react";
+
+import { RootlyIncidentsPage } from "./RootlyIncidentsPage/RootlyIncidentsPage";
+import { RootlyPage } from "./RootlyPage/RootlyPage";
+
+const mockUseOutlet = jest.fn();
+
+jest.mock("react-router", () => ({
+  useOutlet: () => mockUseOutlet(),
+}));
+jest.mock("./RootlyPage/DefaultRootlyPage", () => ({
+  DefaultRootlyPage: ({ organizationId }: { organizationId?: string }) => (
+    <div>Default Rootly page {organizationId}</div>
+  ),
+}));
+jest.mock("./RootlyIncidentsPage/DefaultRootlyIncidentsPage", () => ({
+  DefaultRootlyIncidentsPage: ({
+    organizationId,
+  }: {
+    organizationId?: string;
+  }) => <div>Default incidents page {organizationId}</div>,
+}));
+
+describe.each([
+  {
+    Component: RootlyPage,
+    defaultText: "Default Rootly page organization-id",
+  },
+  {
+    Component: RootlyIncidentsPage,
+    defaultText: "Default incidents page organization-id",
+  },
+])("page outlet handling", ({ Component, defaultText }) => {
+  beforeEach(() => mockUseOutlet.mockReset());
+
+  it("renders its default page and forwards the organization", () => {
+    mockUseOutlet.mockReturnValue(null);
+
+    render(<Component organizationId="organization-id" />);
+
+    expect(screen.getByText(defaultText)).toBeInTheDocument();
+  });
+
+  it("renders a nested route outlet instead of the default page", () => {
+    mockUseOutlet.mockReturnValue(<div>Nested route</div>);
+
+    render(<Component organizationId="organization-id" />);
+
+    expect(screen.getByText("Nested route")).toBeInTheDocument();
+    expect(screen.queryByText(defaultText)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ResourceTables.test.tsx
+++ b/src/components/ResourceTables.test.tsx
@@ -1,0 +1,237 @@
+/** @jsxRuntime automatic */
+import type {
+  RootlyFunctionality,
+  RootlyTeam,
+} from "@rootly/backstage-plugin-common";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentType, ReactNode } from "react";
+
+import { FunctionalitiesTable } from "./FunctionalitiesTable/FunctionalitiesTable";
+import { TeamsTable } from "./TeamsTable/TeamsTable";
+
+type Resource = RootlyFunctionality | RootlyTeam;
+type TableProps = { organizationId?: string; params?: { filter?: object } };
+
+const mockGetFunctionalities = jest.fn();
+const mockGetFunctionalityDetailsURL = jest.fn();
+const mockGetTeams = jest.fn();
+const mockGetTeamDetailsURL = jest.fn();
+const mockUseRootlyClient = jest.fn();
+
+jest.mock("../api", () => ({
+  useRootlyClient: (options: unknown) => mockUseRootlyClient(options),
+}));
+jest.mock("@material-ui/core", () => ({
+  makeStyles: () => () => ({ empty: "empty", searchContainer: "search" }),
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+jest.mock("@material-ui/core/Link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+jest.mock("@material-ui/lab", () => ({
+  Alert: ({ children }: { children: ReactNode }) => (
+    <div role="alert">{children}</div>
+  ),
+}));
+jest.mock("@backstage/plugin-catalog-react", () => ({
+  EntityRefLink: ({ entityRef }: { entityRef: { name: string } }) => (
+    <div>Backstage entity {entityRef.name}</div>
+  ),
+}));
+jest.mock("@backstage/plugin-search-react", () => ({
+  SearchBarBase: ({
+    onChange,
+    placeholder,
+    value,
+  }: {
+    onChange: (value: string) => void;
+    placeholder: string;
+    value: string;
+  }) => (
+    <input
+      aria-label={placeholder}
+      onChange={(event) => onChange(event.target.value)}
+      value={value}
+    />
+  ),
+}));
+jest.mock("@backstage/core-components", () => ({
+  Table: ({
+    columns,
+    data,
+    emptyContent,
+    onPageChange,
+    onRowsPerPageChange,
+  }: {
+    columns: Array<{
+      field: string;
+      render?: (row: Resource) => ReactNode;
+    }>;
+    data: Resource[];
+    emptyContent: ReactNode;
+    onPageChange: (page: number) => void;
+    onRowsPerPageChange: (size: number) => void;
+  }) => (
+    <div>
+      {data.length === 0 && emptyContent}
+      {data.map((row) => (
+        <div key={row.id}>
+          {columns.map((column) => (
+            <div key={column.field}>{column.render?.(row)}</div>
+          ))}
+        </div>
+      ))}
+      <button type="button" onClick={() => onPageChange(1)}>
+        Next page
+      </button>
+      <button type="button" onClick={() => onRowsPerPageChange(25)}>
+        Show 25
+      </button>
+    </div>
+  ),
+}));
+
+const resource = (type: "teams" | "functionalities"): Resource =>
+  ({
+    id: `${type}-id`,
+    type,
+    attributes: {
+      backstage_id: `component:default/${type}`,
+      created_at: "2026-01-01T00:00:00Z",
+      description: `${type} description`,
+      incidents_count: 2,
+      name: type === "teams" ? "Reliability" : "Checkout",
+      updated_at: "2026-01-02T00:00:00Z",
+    },
+  }) as unknown as Resource;
+
+const response = (data: Resource[]) => ({
+  data,
+  meta: { total_count: data.length },
+});
+
+const cases: Array<{
+  api: jest.Mock;
+  component: ComponentType<TableProps>;
+  details: jest.Mock;
+  empty: string;
+  name: string;
+  placeholder: string;
+  type: "teams" | "functionalities";
+}> = [
+  {
+    api: mockGetTeams,
+    component: TeamsTable,
+    details: mockGetTeamDetailsURL,
+    empty: "No teams",
+    name: "Reliability",
+    placeholder: "Search Teams",
+    type: "teams",
+  },
+  {
+    api: mockGetFunctionalities,
+    component: FunctionalitiesTable,
+    details: mockGetFunctionalityDetailsURL,
+    empty: "No functionalities",
+    name: "Checkout",
+    placeholder: "Search Functionalities",
+    type: "functionalities",
+  },
+];
+
+describe.each(cases)("$type table", (testCase) => {
+  const TableComponent = testCase.component;
+
+  beforeEach(() => {
+    mockGetTeams.mockReset().mockResolvedValue(response([]));
+    mockGetFunctionalities.mockReset().mockResolvedValue(response([]));
+    mockGetTeamDetailsURL.mockReset().mockReturnValue("https://rootly/team");
+    mockGetFunctionalityDetailsURL
+      .mockReset()
+      .mockReturnValue("https://rootly/functionality");
+    mockUseRootlyClient.mockReset().mockReturnValue({
+      getFunctionalities: mockGetFunctionalities,
+      getFunctionalityDetailsURL: mockGetFunctionalityDetailsURL,
+      getTeams: mockGetTeams,
+      getTeamDetailsURL: mockGetTeamDetailsURL,
+    });
+  });
+
+  it("passes organization, filters, and pagination to Rootly", async () => {
+    render(
+      <TableComponent
+        organizationId="organization-id"
+        params={{ filter: { status: "active" } }}
+      />,
+    );
+
+    await waitFor(() => expect(testCase.api).toHaveBeenCalled());
+    expect(mockUseRootlyClient).toHaveBeenCalledWith({
+      organizationId: "organization-id",
+    });
+    expect(testCase.api).toHaveBeenLastCalledWith({
+      filter: { search: "", status: "active" },
+      page: { number: 1, size: 10 },
+    });
+  });
+
+  it("renders Rootly and Backstage links", async () => {
+    testCase.api.mockResolvedValue(response([resource(testCase.type)]));
+
+    render(<TableComponent />);
+
+    expect(await screen.findByText(testCase.name)).toHaveAttribute(
+      "href",
+      expect.stringContaining("https://rootly/"),
+    );
+    expect(
+      screen.getByText(`Backstage entity ${testCase.type}`),
+    ).toBeInTheDocument();
+  });
+
+  it("renders empty and error states", async () => {
+    const { unmount } = render(<TableComponent />);
+    expect(await screen.findByText(testCase.empty)).toBeInTheDocument();
+    unmount();
+
+    testCase.api.mockRejectedValue(new Error("Rootly unavailable"));
+    render(<TableComponent />);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Rootly unavailable",
+    );
+  });
+
+  it("refetches for search and pagination", async () => {
+    const user = userEvent.setup();
+    render(<TableComponent />);
+    await waitFor(() => expect(testCase.api).toHaveBeenCalledTimes(1));
+
+    await user.type(screen.getByLabelText(testCase.placeholder), "critical");
+    await waitFor(() =>
+      expect(testCase.api).toHaveBeenLastCalledWith({
+        filter: { search: "critical" },
+        page: { number: 1, size: 10 },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+    await waitFor(() =>
+      expect(testCase.api).toHaveBeenLastCalledWith({
+        filter: { search: "critical" },
+        page: { number: 2, size: 10 },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show 25" }));
+    await waitFor(() =>
+      expect(testCase.api).toHaveBeenLastCalledWith({
+        filter: { search: "critical" },
+        page: { number: 2, size: 25 },
+      }),
+    );
+  });
+});

--- a/src/components/RootlyIncidentsPage/DefaultRootlyIncidentsPage.test.tsx
+++ b/src/components/RootlyIncidentsPage/DefaultRootlyIncidentsPage.test.tsx
@@ -1,0 +1,206 @@
+/** @jsxRuntime automatic */
+import type { Entity } from "@backstage/catalog-model";
+import {
+  ROOTLY_ANNOTATION_FUNCTIONALITY_ID,
+  ROOTLY_ANNOTATION_FUNCTIONALITY_SLUG,
+  ROOTLY_ANNOTATION_ORG_ID,
+  ROOTLY_ANNOTATION_SERVICE_ID,
+  ROOTLY_ANNOTATION_SERVICE_SLUG,
+  ROOTLY_ANNOTATION_TEAM_ID,
+  ROOTLY_ANNOTATION_TEAM_SLUG,
+} from "@rootly/backstage-plugin-common";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { DefaultRootlyIncidentsPage } from "./DefaultRootlyIncidentsPage";
+
+const mockUseApi = jest.fn();
+const mockUseEntity = jest.fn();
+
+jest.mock("@backstage/core-plugin-api", () => ({
+  ...jest.requireActual("@backstage/core-plugin-api"),
+  useApi: () => mockUseApi(),
+}));
+jest.mock("@backstage/plugin-catalog-react", () => ({
+  ...jest.requireActual("@backstage/plugin-catalog-react"),
+  useEntity: () => mockUseEntity(),
+}));
+jest.mock("./RootlyServiceIncidentsPageLayout", () => ({
+  RootlyServiceIncidentsPageLayout: ({
+    organizationId,
+  }: {
+    organizationId?: string;
+  }) => <div>service incidents for {organizationId}</div>,
+}));
+jest.mock("./RootlyFunctionalityIncidentsPageLayout", () => ({
+  RootlyFunctionalityIncidentsPageLayout: ({
+    organizationId,
+  }: {
+    organizationId?: string;
+  }) => <div>functionality incidents for {organizationId}</div>,
+}));
+jest.mock("./RootlyTeamIncidentsPageLayout", () => ({
+  RootlyTeamIncidentsPageLayout: ({
+    organizationId,
+  }: {
+    organizationId?: string;
+  }) => <div>team incidents for {organizationId}</div>,
+}));
+jest.mock("./RootlySystemIncidentsPageLayout", () => ({
+  RootlySystemIncidentsPageLayout: ({ entities }: { entities: Entity[] }) => (
+    <div>
+      system incidents for{" "}
+      {entities.map((entity) => entity.metadata.name).join(",")}
+    </div>
+  ),
+}));
+
+const entityWithAnnotations = (
+  annotations?: Record<string, string>,
+  overrides: Partial<Entity> = {},
+): Entity => ({
+  apiVersion: "backstage.io/v1alpha1",
+  kind: "Component",
+  ...overrides,
+  metadata: { annotations, name: "example", ...overrides.metadata },
+});
+
+const dispatchCases = [
+  [ROOTLY_ANNOTATION_SERVICE_ID, "service incidents"],
+  [ROOTLY_ANNOTATION_SERVICE_SLUG, "service incidents"],
+  [ROOTLY_ANNOTATION_FUNCTIONALITY_ID, "functionality incidents"],
+  [ROOTLY_ANNOTATION_FUNCTIONALITY_SLUG, "functionality incidents"],
+  [ROOTLY_ANNOTATION_TEAM_ID, "team incidents"],
+  [ROOTLY_ANNOTATION_TEAM_SLUG, "team incidents"],
+] as const;
+
+describe("DefaultRootlyIncidentsPage", () => {
+  const catalogApi = { getEntityByRef: jest.fn() };
+
+  beforeEach(() => {
+    catalogApi.getEntityByRef.mockReset();
+    mockUseApi.mockReturnValue(catalogApi);
+  });
+
+  it.each(dispatchCases)(
+    "dispatches %s entities to the expected incidents layout",
+    async (annotation, expected) => {
+      mockUseEntity.mockReturnValue({
+        entity: entityWithAnnotations({
+          [annotation]: "rootly-id",
+          [ROOTLY_ANNOTATION_ORG_ID]: "organization-from-entity",
+        }),
+      });
+
+      render(<DefaultRootlyIncidentsPage />);
+
+      expect(
+        await screen.findByText(`${expected} for organization-from-entity`),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it("prefers an explicitly supplied organization", async () => {
+    mockUseEntity.mockReturnValue({
+      entity: entityWithAnnotations({
+        [ROOTLY_ANNOTATION_ORG_ID]: "organization-from-entity",
+        [ROOTLY_ANNOTATION_SERVICE_ID]: "service",
+      }),
+    });
+
+    render(
+      <DefaultRootlyIncidentsPage organizationId="organization-from-props" />,
+    );
+
+    expect(
+      await screen.findByText("service incidents for organization-from-props"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a fallback for an entity without supported annotations", async () => {
+    mockUseEntity.mockReturnValue({ entity: entityWithAnnotations() });
+
+    render(<DefaultRootlyIncidentsPage />);
+
+    expect(
+      await screen.findByText("No Rootly annotations found"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a fallback for a System without hasPart relations", async () => {
+    mockUseEntity.mockReturnValue({
+      entity: entityWithAnnotations(undefined, { kind: "System" }),
+    });
+
+    render(<DefaultRootlyIncidentsPage />);
+
+    expect(
+      await screen.findByText("No Rootly annotations found"),
+    ).toBeInTheDocument();
+    expect(catalogApi.getEntityByRef).not.toHaveBeenCalled();
+  });
+
+  it("resolves a single annotated System child", async () => {
+    const system = entityWithAnnotations(undefined, {
+      kind: "System",
+      relations: [{ targetRef: "component:default/child", type: "hasPart" }],
+    });
+    catalogApi.getEntityByRef.mockResolvedValue(
+      entityWithAnnotations({
+        [ROOTLY_ANNOTATION_ORG_ID]: "child-organization",
+        [ROOTLY_ANNOTATION_SERVICE_ID]: "service",
+      }),
+    );
+    mockUseEntity.mockReturnValue({ entity: system });
+
+    render(<DefaultRootlyIncidentsPage />);
+
+    expect(
+      await screen.findByText("service incidents for child-organization"),
+    ).toBeInTheDocument();
+    expect(catalogApi.getEntityByRef).toHaveBeenCalledWith(
+      "component:default/child",
+    );
+  });
+
+  it("aggregates multiple annotated System children and ignores unconfigured children", async () => {
+    const system = entityWithAnnotations(undefined, {
+      kind: "System",
+      relations: [
+        { targetRef: "component:default/service", type: "hasPart" },
+        { targetRef: "component:default/team", type: "hasPart" },
+        { targetRef: "component:default/unconfigured", type: "hasPart" },
+        { targetRef: "component:default/ignored", type: "ownedBy" },
+      ],
+    });
+    catalogApi.getEntityByRef
+      .mockResolvedValueOnce(
+        entityWithAnnotations(
+          {
+            [ROOTLY_ANNOTATION_ORG_ID]: "first-organization",
+            [ROOTLY_ANNOTATION_SERVICE_ID]: "service",
+          },
+          { metadata: { name: "service-child" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        entityWithAnnotations(
+          {
+            [ROOTLY_ANNOTATION_ORG_ID]: "second-organization",
+            [ROOTLY_ANNOTATION_TEAM_ID]: "team",
+          },
+          { metadata: { name: "team-child" } },
+        ),
+      )
+      .mockResolvedValueOnce(entityWithAnnotations());
+    mockUseEntity.mockReturnValue({ entity: system });
+
+    render(<DefaultRootlyIncidentsPage />);
+
+    expect(
+      await screen.findByText("system incidents for service-child,team-child"),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(catalogApi.getEntityByRef).toHaveBeenCalledTimes(3),
+    );
+  });
+});

--- a/src/components/RootlyIncidentsPage/RootlySystemIncidentsPageLayout.test.tsx
+++ b/src/components/RootlyIncidentsPage/RootlySystemIncidentsPageLayout.test.tsx
@@ -1,0 +1,189 @@
+/** @jsxRuntime automatic */
+import {
+  ROOTLY_ANNOTATION_ORG_ID,
+  type RootlyEntity,
+} from "@rootly/backstage-plugin-common";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { RootlySystemIncidentsPageLayout } from "./RootlySystemIncidentsPageLayout";
+
+const mockUseRootlyClient = jest.fn();
+
+jest.mock("../../api", () => ({
+  useRootlyClient: (options: unknown) => mockUseRootlyClient(options),
+}));
+jest.mock("@backstage/core-components", () => ({
+  Content: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ContentHeader: ({ title }: { title: string }) => <h2>{title}</h2>,
+  Page: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+  Progress: () => <div>Loading system incidents</div>,
+}));
+jest.mock("@material-ui/core", () => ({
+  Grid: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+jest.mock("@material-ui/lab", () => ({
+  Alert: ({ children }: { children: ReactNode }) => (
+    <div role="alert">{children}</div>
+  ),
+}));
+jest.mock("../IncidentsTable", () => ({
+  IncidentsTable: ({
+    organizationId,
+    params,
+  }: {
+    organizationId: string;
+    params: {
+      filter: {
+        functionalities: string;
+        groups: string;
+        services: string;
+        status?: string;
+      };
+    };
+  }) => (
+    <div
+      data-testid={`incidents-${organizationId}-${
+        params.filter.status ? "ongoing" : "past"
+      }`}
+    >
+      {JSON.stringify(params.filter)}
+    </div>
+  ),
+}));
+
+const entity = (
+  name: string,
+  organizationId: string,
+  rootlyKind: "Service" | "Functionality" | "Team",
+): RootlyEntity =>
+  ({
+    apiVersion: "backstage.io/v1alpha1",
+    kind: "Component",
+    metadata: {
+      annotations: { [ROOTLY_ANNOTATION_ORG_ID]: organizationId },
+      name,
+    },
+    rootlyKind,
+  }) as unknown as RootlyEntity;
+
+const resource = (slug: string) => ({ attributes: { slug } });
+
+const client = () => ({
+  getFunctionalities: jest.fn().mockResolvedValue({ data: [] }),
+  getServices: jest.fn().mockResolvedValue({ data: [] }),
+  getTeams: jest.fn().mockResolvedValue({ data: [] }),
+});
+
+describe("RootlySystemIncidentsPageLayout", () => {
+  beforeEach(() => {
+    mockUseRootlyClient.mockReset();
+  });
+
+  it("aggregates resources per organization into ongoing and past incident filters", async () => {
+    const organizationA = client();
+    organizationA.getServices.mockResolvedValue({
+      data: [resource("service-a")],
+    });
+    organizationA.getFunctionalities.mockResolvedValue({
+      data: [resource("functionality-a")],
+    });
+    organizationA.getTeams.mockResolvedValue({ data: [resource("team-a")] });
+    const organizationB = client();
+    organizationB.getServices.mockResolvedValue({
+      data: [resource("service-b")],
+    });
+
+    mockUseRootlyClient.mockImplementation(
+      ({ organizationId }: { organizationId: string }) =>
+        organizationId === "organization-a" ? organizationA : organizationB,
+    );
+
+    render(
+      <RootlySystemIncidentsPageLayout
+        entities={[
+          entity("service-a", "organization-a", "Service"),
+          entity("functionality-a", "organization-a", "Functionality"),
+          entity("team-a", "organization-a", "Team"),
+          entity("service-b", "organization-b", "Service"),
+        ]}
+      />,
+    );
+
+    expect(
+      JSON.parse(
+        (await screen.findByTestId("incidents-organization-a-ongoing"))
+          .textContent ?? "{}",
+      ),
+    ).toEqual({
+      functionalities: "functionality-a",
+      groups: "team-a",
+      services: "service-a",
+      status: "started,mitigated",
+    });
+    expect(
+      JSON.parse(
+        screen.getByTestId("incidents-organization-a-past").textContent ?? "{}",
+      ),
+    ).toEqual({
+      functionalities: "functionality-a",
+      groups: "team-a",
+      services: "service-a",
+    });
+    expect(
+      screen.getByTestId("incidents-organization-b-ongoing"),
+    ).toHaveTextContent('"services":"service-b"');
+
+    expect(organizationA.getServices).toHaveBeenCalledWith({
+      filter: { backstage_id: "component:default/service-a" },
+    });
+    expect(organizationA.getFunctionalities).toHaveBeenCalledWith({
+      filter: { backstage_id: "component:default/functionality-a" },
+    });
+    expect(organizationA.getTeams).toHaveBeenCalledWith({
+      filter: { backstage_id: "component:default/team-a" },
+    });
+  });
+
+  it("keeps rendering successful resource types when one request fails", async () => {
+    const organization = client();
+    organization.getServices.mockRejectedValue(
+      new Error("services unavailable"),
+    );
+    organization.getTeams.mockResolvedValue({ data: [resource("team-a")] });
+    mockUseRootlyClient.mockReturnValue(organization);
+
+    render(
+      <RootlySystemIncidentsPageLayout
+        entities={[
+          entity("service-a", "organization-a", "Service"),
+          entity("team-a", "organization-a", "Team"),
+        ]}
+      />,
+    );
+
+    expect(
+      JSON.parse(
+        (await screen.findByTestId("incidents-organization-a-ongoing"))
+          .textContent ?? "{}",
+      ),
+    ).toEqual({
+      functionalities: "",
+      groups: "team-a",
+      services: "",
+      status: "started,mitigated",
+    });
+  });
+
+  it("does not request or render organizations when the System has no Rootly children", async () => {
+    render(<RootlySystemIncidentsPageLayout entities={[]} />);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Loading system incidents"),
+      ).not.toBeInTheDocument(),
+    );
+    expect(mockUseRootlyClient).not.toHaveBeenCalled();
+    expect(screen.queryByTestId(/incidents-/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/RootlyPage/DefaultRootlyPageLayout.test.tsx
+++ b/src/components/RootlyPage/DefaultRootlyPageLayout.test.tsx
@@ -1,0 +1,95 @@
+/** @jsxRuntime automatic */
+import { render, screen } from "@testing-library/react";
+import { Fragment, type ReactNode } from "react";
+
+import { DefaultRootlyPageLayout } from "./DefaultRootlyPageLayout";
+
+const mockRoutedTabs = jest.fn(
+  ({
+    routes,
+  }: {
+    routes: Array<{ path: string; tabProps?: object; title: string }>;
+  }) => (
+    <div>
+      {routes.map((route) => (
+        <div key={route.path}>{`${route.title}:${route.path}`}</div>
+      ))}
+    </div>
+  ),
+);
+
+jest.mock("@backstage/core-components", () => ({
+  Header: ({ title }: { title: string }) => <h1>{title}</h1>,
+  Page: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+  RoutedTabs: (props: unknown) => mockRoutedTabs(props as never),
+}));
+
+describe("DefaultRootlyPageLayout", () => {
+  beforeEach(() => mockRoutedTabs.mockClear());
+
+  it("turns Route children into routed tabs", () => {
+    render(
+      <DefaultRootlyPageLayout>
+        <DefaultRootlyPageLayout.Route path="/incidents" title="Incidents">
+          <div>Incident content</div>
+        </DefaultRootlyPageLayout.Route>
+        <DefaultRootlyPageLayout.Route path="/services" title="Services">
+          <div>Service content</div>
+        </DefaultRootlyPageLayout.Route>
+      </DefaultRootlyPageLayout>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Rootly" })).toBeInTheDocument();
+    expect(screen.getByText("Incidents:/incidents")).toBeInTheDocument();
+    expect(screen.getByText("Services:/services")).toBeInTheDocument();
+    expect(mockRoutedTabs.mock.calls[0][0].routes).toEqual([
+      expect.objectContaining({ path: "/incidents", title: "Incidents" }),
+      expect.objectContaining({ path: "/services", title: "Services" }),
+    ]);
+  });
+
+  it("flattens fragments and ignores non-elements", () => {
+    render(
+      <DefaultRootlyPageLayout>
+        text is ignored
+        <Fragment>
+          <DefaultRootlyPageLayout.Route path="/teams" title="Teams">
+            <div>Team content</div>
+          </DefaultRootlyPageLayout.Route>
+        </Fragment>
+      </DefaultRootlyPageLayout>,
+    );
+
+    expect(screen.getByText("Teams:/teams")).toBeInTheDocument();
+  });
+
+  it("preserves tab properties", () => {
+    render(
+      <DefaultRootlyPageLayout>
+        <DefaultRootlyPageLayout.Route
+          path="/services"
+          title="Services"
+          tabProps={{ disabled: true }}
+        >
+          <div />
+        </DefaultRootlyPageLayout.Route>
+      </DefaultRootlyPageLayout>,
+    );
+
+    expect(mockRoutedTabs.mock.calls[0][0].routes[0].tabProps).toEqual({
+      disabled: true,
+    });
+  });
+
+  it("rejects arbitrary element children with a Rootly-specific error", () => {
+    expect(() =>
+      render(
+        <DefaultRootlyPageLayout>
+          <div>Invalid child</div>
+        </DefaultRootlyPageLayout>,
+      ),
+    ).toThrow(
+      "Child of DefaultRootlyPageLayout must be a DefaultRootlyPageLayout.Route",
+    );
+  });
+});

--- a/src/components/RootlyPage/DefaultRootlyPageLayout.tsx
+++ b/src/components/RootlyPage/DefaultRootlyPageLayout.tsx
@@ -36,7 +36,7 @@ function createSubRoutesFromChildren(childrenProps: React.ReactNode): SubRoute[]
     }
 
     if (child.type !== routeType) {
-      throw new Error('Child of ExploreLayout must be an ExploreLayout.Route');
+      throw new Error('Child of DefaultRootlyPageLayout must be a DefaultRootlyPageLayout.Route');
     }
 
     const { path, title, children, tabProps } = child.props;

--- a/src/components/ServicesTable/ServicesTable.test.tsx
+++ b/src/components/ServicesTable/ServicesTable.test.tsx
@@ -1,0 +1,236 @@
+/** @jsxRuntime automatic */
+import type { RootlyService } from "@rootly/backstage-plugin-common";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+
+import { ServicesTable } from "./ServicesTable";
+
+const mockGetServices = jest.fn();
+const mockGetServiceDetailsURL = jest.fn();
+const mockUseRootlyClient = jest.fn();
+
+jest.mock("../../api", () => ({
+  useRootlyClient: (options: unknown) => mockUseRootlyClient(options),
+}));
+jest.mock("@material-ui/core", () => ({
+  makeStyles: () => () => ({ empty: "empty", searchContainer: "search" }),
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+jest.mock("@material-ui/core/Link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+jest.mock("@material-ui/lab", () => ({
+  Alert: ({ children }: { children: ReactNode }) => (
+    <div role="alert">{children}</div>
+  ),
+}));
+jest.mock("@backstage/plugin-catalog-react", () => ({
+  EntityRefLink: ({ entityRef }: { entityRef: { name: string } }) => (
+    <div>Backstage entity {entityRef.name}</div>
+  ),
+}));
+jest.mock("@backstage/plugin-search-react", () => ({
+  SearchBarBase: ({
+    onChange,
+    placeholder,
+    value,
+  }: {
+    onChange: (value: string) => void;
+    placeholder: string;
+    value: string;
+  }) => (
+    <input
+      aria-label={placeholder}
+      onChange={(event) => onChange(event.target.value)}
+      value={value}
+    />
+  ),
+}));
+jest.mock("@backstage/core-components", () => ({
+  Table: ({
+    columns,
+    data,
+    emptyContent,
+    isLoading,
+    onPageChange,
+    onRowsPerPageChange,
+  }: {
+    columns: Array<{
+      field: string;
+      render?: (row: RootlyService) => ReactNode;
+    }>;
+    data: RootlyService[];
+    emptyContent: ReactNode;
+    isLoading: boolean;
+    onPageChange: (page: number) => void;
+    onRowsPerPageChange: (size: number) => void;
+  }) => (
+    <div>
+      {isLoading && <div>Loading services</div>}
+      {!isLoading && data.length === 0 && emptyContent}
+      {data.map((row) => (
+        <div key={row.id}>
+          {columns.map((column) => (
+            <div key={column.field}>
+              {column.render?.(row) ??
+                String(
+                  row.attributes[
+                    column.field.replace(
+                      "attributes.",
+                      "",
+                    ) as keyof typeof row.attributes
+                  ] ?? "",
+                )}
+            </div>
+          ))}
+        </div>
+      ))}
+      <button type="button" onClick={() => onPageChange(1)}>
+        Next page
+      </button>
+      <button type="button" onClick={() => onRowsPerPageChange(25)}>
+        Show 25
+      </button>
+    </div>
+  ),
+}));
+
+const service = (backstageId?: string): RootlyService =>
+  ({
+    id: "service-id",
+    type: "services",
+    attributes: {
+      backstage_id: backstageId,
+      created_at: "2026-01-01T00:00:00Z",
+      description: "Service description",
+      incidents_count: 2,
+      name: "Payments",
+      updated_at: "2026-01-02T00:00:00Z",
+    },
+  }) as unknown as RootlyService;
+
+const response = (data: RootlyService[]) => ({
+  data,
+  meta: { total_count: data.length },
+});
+
+describe("ServicesTable", () => {
+  beforeEach(() => {
+    mockGetServices.mockReset();
+    mockGetServiceDetailsURL.mockReset();
+    mockGetServices.mockResolvedValue(response([]));
+    mockGetServiceDetailsURL.mockReturnValue(
+      "https://rootly.example/services/service-id",
+    );
+    mockUseRootlyClient.mockReturnValue({
+      getServiceDetailsURL: mockGetServiceDetailsURL,
+      getServices: mockGetServices,
+    });
+  });
+
+  it("passes organization, filters, and default pagination to Rootly", async () => {
+    render(
+      <ServicesTable
+        organizationId="organization-id"
+        params={{ filter: { status: "operational" } }}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetServices).toHaveBeenCalled());
+    expect(mockUseRootlyClient).toHaveBeenCalledWith({
+      organizationId: "organization-id",
+    });
+    expect(mockGetServices).toHaveBeenLastCalledWith({
+      filter: { search: "", status: "operational" },
+      page: { number: 1, size: 10 },
+    });
+  });
+
+  it("renders returned services and their Rootly links", async () => {
+    mockGetServices.mockResolvedValue(response([service()]));
+
+    render(<ServicesTable />);
+
+    expect(await screen.findByText("Payments")).toHaveAttribute(
+      "href",
+      "https://rootly.example/services/service-id",
+    );
+    expect(screen.getByText("N/A")).toBeInTheDocument();
+  });
+
+  it("renders a Backstage entity link for a valid reference", async () => {
+    mockGetServices.mockResolvedValue(
+      response([service("component:default/payments")]),
+    );
+
+    render(<ServicesTable />);
+
+    expect(
+      await screen.findByText("Backstage entity payments"),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back safely for a malformed Backstage entity reference", async () => {
+    mockGetServices.mockResolvedValue(response([service(":not-valid")]));
+
+    render(<ServicesTable />);
+
+    expect(await screen.findByText("N/A")).toBeInTheDocument();
+  });
+
+  it("renders the empty state", async () => {
+    render(<ServicesTable />);
+
+    expect(await screen.findByText("No services")).toBeInTheDocument();
+  });
+
+  it("renders API errors", async () => {
+    mockGetServices.mockRejectedValue(new Error("Rootly unavailable"));
+
+    render(<ServicesTable />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Rootly unavailable",
+    );
+  });
+
+  it("refetches when the user searches", async () => {
+    const user = userEvent.setup();
+    render(<ServicesTable />);
+    await waitFor(() => expect(mockGetServices).toHaveBeenCalledTimes(1));
+
+    await user.type(screen.getByLabelText("Search Services"), "payments");
+
+    await waitFor(() =>
+      expect(mockGetServices).toHaveBeenLastCalledWith({
+        filter: { search: "payments" },
+        page: { number: 1, size: 10 },
+      }),
+    );
+  });
+
+  it("refetches when pagination changes", async () => {
+    render(<ServicesTable />);
+    await waitFor(() => expect(mockGetServices).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+    await waitFor(() =>
+      expect(mockGetServices).toHaveBeenLastCalledWith({
+        filter: { search: "" },
+        page: { number: 2, size: 10 },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show 25" }));
+    await waitFor(() =>
+      expect(mockGetServices).toHaveBeenLastCalledWith({
+        filter: { search: "" },
+        page: { number: 2, size: 25 },
+      }),
+    );
+  });
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,84 @@
+import { loadConfigSchema } from "@backstage/config-loader";
+import { resolve } from "node:path";
+
+const fullConfig = {
+  rootly: {
+    primary: {
+      apiKey: "must-not-reach-the-browser",
+      apiHost: "https://rootly.example",
+      isDefault: true,
+      proxyPath: "/api/proxy/rootly",
+    },
+  },
+};
+
+describe("Rootly configuration schema", () => {
+  const schemaPromise = loadConfigSchema({
+    dependencies: [],
+    excludePackageDependencies: true,
+    packagePaths: [resolve(process.cwd(), "package.json")],
+  });
+
+  it("marks the API key as secret and runtime settings as frontend-visible", async () => {
+    const schema = await schemaPromise;
+    const serialized = schema.serialize() as {
+      schemas: Array<{
+        value: {
+          properties: {
+            rootly: {
+              additionalProperties: {
+                properties: Record<string, { visibility?: string }>;
+              };
+            };
+          };
+        };
+      }>;
+    };
+    const properties =
+      serialized.schemas[0].value.properties.rootly.additionalProperties
+        .properties;
+
+    expect(properties.apiKey.visibility).toBe("secret");
+    expect(properties.apiHost.visibility).toBe("frontend");
+    expect(properties.isDefault.visibility).toBe("frontend");
+    expect(properties.proxyPath.visibility).toBe("frontend");
+  });
+
+  it("removes API keys from frontend configuration", async () => {
+    const schema = await schemaPromise;
+
+    expect(
+      schema.process([{ context: "test", data: fullConfig }], {
+        visibility: ["frontend"],
+      }),
+    ).toEqual([
+      {
+        context: "test",
+        data: {
+          rootly: {
+            primary: {
+              apiHost: "https://rootly.example",
+              isDefault: true,
+              proxyPath: "/api/proxy/rootly",
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("accepts proxy configuration without the deprecated API key", async () => {
+    const schema = await schemaPromise;
+    const proxyOnlyConfig = {
+      rootly: {
+        primary: {
+          proxyPath: "/api/proxy/rootly",
+        },
+      },
+    };
+
+    expect(
+      schema.process([{ context: "test", data: proxyOnlyConfig }]),
+    ).toEqual([{ context: "test", data: proxyOnlyConfig }]);
+  });
+});

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,0 +1,67 @@
+import type { Entity } from "@backstage/catalog-model";
+import {
+  ROOTLY_ANNOTATION_CATALOG_ENTITY_ID,
+  ROOTLY_ANNOTATION_CATALOG_ENTITY_SLUG,
+  ROOTLY_ANNOTATION_FUNCTIONALITY_ID,
+  ROOTLY_ANNOTATION_FUNCTIONALITY_SLUG,
+  ROOTLY_ANNOTATION_SERVICE_ID,
+  ROOTLY_ANNOTATION_SERVICE_SLUG,
+  ROOTLY_ANNOTATION_TEAM_ID,
+  ROOTLY_ANNOTATION_TEAM_SLUG,
+} from "@rootly/backstage-plugin-common";
+
+import { isRootlyAvailable } from "./integration";
+
+const rootlyAnnotations = [
+  ROOTLY_ANNOTATION_SERVICE_ID,
+  ROOTLY_ANNOTATION_SERVICE_SLUG,
+  ROOTLY_ANNOTATION_FUNCTIONALITY_ID,
+  ROOTLY_ANNOTATION_FUNCTIONALITY_SLUG,
+  ROOTLY_ANNOTATION_TEAM_ID,
+  ROOTLY_ANNOTATION_TEAM_SLUG,
+  ROOTLY_ANNOTATION_CATALOG_ENTITY_ID,
+  ROOTLY_ANNOTATION_CATALOG_ENTITY_SLUG,
+];
+
+const entityWithAnnotations = (
+  annotations?: Record<string, string>,
+): Entity => ({
+  apiVersion: "backstage.io/v1alpha1",
+  kind: "Component",
+  metadata: {
+    name: "example",
+    annotations,
+  },
+});
+
+describe("isRootlyAvailable", () => {
+  it.each(rootlyAnnotations)(
+    "is available for the %s annotation",
+    (annotation) => {
+      expect(
+        isRootlyAvailable(entityWithAnnotations({ [annotation]: "rootly-id" })),
+      ).toBe(true);
+    },
+  );
+
+  it("is unavailable when annotations are missing", () => {
+    expect(isRootlyAvailable(entityWithAnnotations())).toBe(false);
+  });
+
+  it.each(rootlyAnnotations)(
+    "is unavailable when the %s annotation is empty",
+    (annotation) => {
+      expect(
+        isRootlyAvailable(entityWithAnnotations({ [annotation]: "" })),
+      ).toBe(false);
+    },
+  );
+
+  it("ignores unrelated annotations", () => {
+    expect(
+      isRootlyAvailable(
+        entityWithAnnotations({ "example.com/unrelated": "value" }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1288,6 +1288,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/connections@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@backstage/connections@npm:0.3.0"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    zod: "npm:^4.0.0"
+  checksum: 10c0/97b7cdf9675bbc458965da85d15b769a314d0e8febb2fb27e1b679cbd5e5c3f661547ad928a9c750ea8889f03879113d31438a06241454dbb39dab631709b4e5
+  languageName: node
+  linkType: hard
+
 "@backstage/core-app-api@npm:^1.20.3":
   version: 1.20.3
   resolution: "@backstage/core-app-api@npm:1.20.3"
@@ -1314,6 +1326,35 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/505b3dac1d91c4f5ae0e63eca9bf619e2f1e9559833036dd190fa81fab9db2908064aa89c0e9ecf15c452a558f48d23c41951a0403b5c3abb44cf292bd6202e9
+  languageName: node
+  linkType: hard
+
+"@backstage/core-app-api@npm:^1.20.4":
+  version: 1.20.4
+  resolution: "@backstage/core-app-api@npm:1.20.4"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/ui": "npm:^0.17.1"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@types/prop-types": "npm:^15.7.3"
+    history: "npm:^5.0.0"
+    i18next: "npm:^22.4.15"
+    lodash: "npm:^4.17.21"
+    prop-types: "npm:^15.7.2"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/a8f3ed20ef3743ab895a2235a2720d55cca983ccbf41e40695e27b3f9812571ef2b0af3f1f0786c2777c7185dd3a3e46d63ef9e54ce58bbe90fa36d7fc860e46
   languageName: node
   linkType: hard
 
@@ -1401,6 +1442,65 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/core-components@npm:^0.18.13":
+  version: 0.18.13
+  resolution: "@backstage/core-components@npm:0.18.13"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/theme": "npm:^0.7.3"
+    "@backstage/ui": "npm:^0.17.1"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    csstype: "npm:^3.0.2"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.3.0"
+    linkify-react: "npm:4.3.2"
+    linkifyjs: "npm:4.3.2"
+    lodash: "npm:^4.17.21"
+    parse5: "npm:^6.0.0"
+    qs: "npm:^6.15.2"
+    rc-progress: "npm:3.5.1"
+    react-full-screen: "npm:^1.1.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    rehype-raw: "npm:^6.0.0"
+    rehype-sanitize: "npm:^5.0.0"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/18694687a9be08799e62749a9ccd9dea006edd029f41ac152af1de1c618afbcdac792ac7914620fee722b48b40711e0830a32d4f36e4519b33d34bc5683c2a75
+  languageName: node
+  linkType: hard
+
 "@backstage/core-plugin-api@npm:^1.12.8":
   version: 1.12.8
   resolution: "@backstage/core-plugin-api@npm:1.12.8"
@@ -1421,6 +1521,29 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/87d99483edca1969a6d56f91b9dccdd1ec544f67f566c0abf15ecfc67984b0322c18128defa841de8fdaaab89be931e8d38a70b14359868056ddd458cbd283bd
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:^1.12.9":
+  version: 1.12.9
+  resolution: "@backstage/core-plugin-api@npm:1.12.9"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/frontend-plugin-api": "npm:^0.18.0"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    history: "npm:^5.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/209c918060adeb48ff81d32d19e139910bb9947d28e47f9b1a4942e15d3ebf2c091d11eda7e6562f3f39d4bd283b08e4b133a45b392a88cceba3a1728f12b5e3
   languageName: node
   linkType: hard
 
@@ -1512,6 +1635,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/frontend-app-api@npm:^0.16.7":
+  version: 0.16.7
+  resolution: "@backstage/frontend-app-api@npm:0.16.7"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/core-app-api": "npm:^1.20.4"
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/frontend-defaults": "npm:^0.5.5"
+    "@backstage/frontend-plugin-api": "npm:^0.18.0"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/061d4e42d0ca5d55e368111bbdf0d1fea9d44d5e55b16c8ad00605d7a8eee363cca68396e98d0ba1aa2760c2d8bf269712922b147a68580ddb2ccd37a4ef12b2
+  languageName: node
+  linkType: hard
+
 "@backstage/frontend-defaults@npm:^0.5.4":
   version: 0.5.4
   resolution: "@backstage/frontend-defaults@npm:0.5.4"
@@ -1532,6 +1681,29 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/851f014b0c89c41232d4bc4cb527afce1cd3b359c88809b9bdeb9a225a4f78d7ea81da2ecdb1039aedeb9d9980b8d55358d7c349d6b29d8ba700c3d0d0aa2df9
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-defaults@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "@backstage/frontend-defaults@npm:0.5.5"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/core-components": "npm:^0.18.13"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/frontend-app-api": "npm:^0.16.7"
+    "@backstage/frontend-plugin-api": "npm:^0.18.0"
+    "@backstage/plugin-app": "npm:^0.5.2"
+    "@react-hookz/web": "npm:^24.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/ee19823794719c430c263c2f2482f053366bf212f3b51de7cca13712e2786bd016f3b780c8d1ebdbe3b010c1559a3689a55290ae66acd71fbc18b9ecd34acacc
   languageName: node
   linkType: hard
 
@@ -1559,6 +1731,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/frontend-plugin-api@npm:^0.18.0":
+  version: 0.18.0
+  resolution: "@backstage/frontend-plugin-api@npm:0.18.0"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@standard-schema/spec": "npm:^1.1.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/30d677b7002706c32ea5426e6b25b49ac905f07f6d5777ae372bfdc90f3be24bde8e09087a6241861f8eaa4abb385153dbb08363fe80321202397ec01d488bf0
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-test-utils@npm:^0.6.2":
+  version: 0.6.3
+  resolution: "@backstage/frontend-test-utils@npm:0.6.3"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/core-app-api": "npm:^1.20.4"
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/frontend-app-api": "npm:^0.16.7"
+    "@backstage/frontend-plugin-api": "npm:^0.18.0"
+    "@backstage/plugin-app": "npm:^0.5.2"
+    "@backstage/plugin-app-react": "npm:^0.2.6"
+    "@backstage/plugin-permission-common": "npm:^0.9.10"
+    "@backstage/plugin-permission-react": "npm:^0.5.4"
+    "@backstage/test-utils": "npm:^1.7.21"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    i18next: "npm:^22.4.15"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/jest": "*"
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/jest":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10c0/276546fc9b2d43e2cac397b8c81c9148db8e2d5fad6d981559dac3013298b3e7d3ad76f9cfe059cb7626a6c6d1745477bbb6fdc619633d38c95e824f610f7edb
+  languageName: node
+  linkType: hard
+
 "@backstage/integration-react@npm:^1.2.20":
   version: 1.2.20
   resolution: "@backstage/integration-react@npm:1.2.20"
@@ -1580,6 +1810,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/integration-react@npm:^1.2.21":
+  version: 1.2.21
+  resolution: "@backstage/integration-react@npm:1.2.21"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/integration": "npm:^2.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/f68dda358ce8829eca9008d8549192d492b9a8877f9080311120541307f3187b6ca65f25c8d3fd708092f96db404bea5fd3975a7887489a9504a39d606c3afab
+  languageName: node
+  linkType: hard
+
 "@backstage/integration@npm:^2.0.3":
   version: 2.0.3
   resolution: "@backstage/integration@npm:2.0.3"
@@ -1596,6 +1847,26 @@ __metadata:
     luxon: "npm:^3.0.0"
     p-throttle: "npm:^4.1.1"
   checksum: 10c0/d56a5be601813b541dbb1899624a4379944ff3c44e3fca47ddd00ca0cf785fc3b4f1beead2be55af8dfa8adc03fb8f804f80784e66d7a85d615c4830a0dbbdb6
+  languageName: node
+  linkType: hard
+
+"@backstage/integration@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@backstage/integration@npm:2.1.0"
+  dependencies:
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/connections": "npm:^0.3.0"
+    "@backstage/errors": "npm:^1.3.1"
+    "@octokit/auth-app": "npm:^4.0.0"
+    "@octokit/rest": "npm:^19.0.3"
+    cross-fetch: "npm:^4.0.0"
+    git-url-parse: "npm:^15.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+    p-throttle: "npm:^4.1.1"
+  checksum: 10c0/bc1cc00ba4affa782c7127f20b058b371dfd947ab633e64d23922538e12512a9a5bd4207b1228e7affb2139d997191f5b86b3ae61216d71d7f16bb33f8b0e5eb
   languageName: node
   linkType: hard
 
@@ -1643,6 +1914,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-app-react@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "@backstage/plugin-app-react@npm:0.2.6"
+  dependencies:
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/frontend-plugin-api": "npm:^0.18.0"
+    "@material-ui/core": "npm:^4.9.13"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/6af5cdd9fdef3a4ae059f77bfc2f0ba86ef27d064516aafca2867ccedc284c6d4b025e6af39b965c26b1c3e6ca1330ce27bd71aaeaa88b54ae50ce62befa57a9
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-app@npm:^0.5.1":
   version: 0.5.1
   resolution: "@backstage/plugin-app@npm:0.5.1"
@@ -1678,6 +1968,44 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/f588bedef9391cf0d4fb3885f5e191e926b1f8c6730519e8aebdfa5469f0ee39ec471ed8b73f136a667af9a55fc7170205e78a2e7d57fd064459c360dbad3164
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-app@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@backstage/plugin-app@npm:0.5.2"
+  dependencies:
+    "@backstage/core-components": "npm:^0.18.13"
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/frontend-plugin-api": "npm:^0.18.0"
+    "@backstage/integration-react": "npm:^1.2.21"
+    "@backstage/plugin-app-react": "npm:^0.2.6"
+    "@backstage/plugin-permission-react": "npm:^0.5.4"
+    "@backstage/theme": "npm:^0.7.3"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/ui": "npm:^0.17.1"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@material-ui/core": "npm:^4.9.13"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:^4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    motion: "npm:^12.0.0"
+    react-aria: "npm:~3.48.0"
+    react-stately: "npm:~3.46.0"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/622637256285c0d32e844fa43c25893e39c50fa8d22aa6cda9ee331db13366ddb8cb490a0e6691ed842d65de5d34c21b67299afb6e18df1cbcafce92028b9a76
   languageName: node
   linkType: hard
 
@@ -1787,6 +2115,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:^0.9.10":
+  version: 0.9.10
+  resolution: "@backstage/plugin-permission-common@npm:0.9.10"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    cross-fetch: "npm:^4.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10c0/7fabd3906d6d7c741b83bfa351287bec44ccb100d5ad6753a25f6ff4055c2ba284bbd7d2ea0853435b66fcc8def19dff229c7d4857e4b21eff06158069860971
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-common@npm:^0.9.9":
   version: 0.9.9
   resolution: "@backstage/plugin-permission-common@npm:0.9.9"
@@ -1818,6 +2160,26 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/2cc5c076fdc7bf28aee8dd68b8073b2f1439a9d8f73b8fb486517f94d84493e4ab36ac3bd4ca92b235d4f41a4849757f288c253488c45821d2c052ef815a32e4
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-react@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@backstage/plugin-permission-react@npm:0.5.4"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/plugin-permission-common": "npm:^0.9.10"
+    dataloader: "npm:^2.0.0"
+    swr: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/672f90c31b786000873755736cc07261a7ad11fe8ab45127fcb293cea320b3ab4677329b922c8d62324925419ba455e1887bff543433252fb5505cd6eaf1dfce
   languageName: node
   linkType: hard
 
@@ -1984,6 +2346,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/test-utils@npm:^1.7.21":
+  version: 1.7.21
+  resolution: "@backstage/test-utils@npm:1.7.21"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/core-app-api": "npm:^1.20.4"
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/plugin-permission-common": "npm:^0.9.10"
+    "@backstage/plugin-permission-react": "npm:^0.5.4"
+    "@backstage/theme": "npm:^0.7.3"
+    "@backstage/types": "npm:^1.2.2"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    cross-fetch: "npm:^4.0.0"
+    i18next: "npm:^22.4.15"
+    zen-observable: "npm:^0.10.0"
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/jest": "*"
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/jest":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10c0/add45a59260b6aad031d04d28abb480f79ac53911ba8abc559551ec881b0f90314cf99ec7cc921b94d13d6c295ff154f10474bb5cb0a726f3cd46e0c28c0d064
+  languageName: node
+  linkType: hard
+
 "@backstage/theme@npm:^0.7.3":
   version: 0.7.3
   resolution: "@backstage/theme@npm:0.7.3"
@@ -2035,6 +2429,33 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/0e36fa81bfc6b872ef69e369e00fae6a020232e49e6997bb81ba027f783d6a8a539ecc761ed93cf5b80c2810ee71a20ef27e475f2a33b8343333c699348ad68d
+  languageName: node
+  linkType: hard
+
+"@backstage/ui@npm:^0.17.1":
+  version: 0.17.1
+  resolution: "@backstage/ui@npm:0.17.1"
+  dependencies:
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@braintree/sanitize-url": "npm:^7.1.2"
+    "@internationalized/date": "npm:^3.12.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    "@tanstack/react-table": "npm:^8.21.3"
+    clsx: "npm:^2.1.1"
+    marked: "npm:^15.0.12"
+    react-aria: "npm:~3.48.0"
+    react-aria-components: "npm:~1.17.0"
+    react-stately: "npm:~3.46.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    "@types/react": ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/88388f9d314665e72c655cb0ad745e812584254805715c80371f0e00731649efd7ea23b0c595b16ea2d132bd4d894ff1bf3b7b8a36277dba650f90f0f2e11c41
   languageName: node
   linkType: hard
 
@@ -4744,6 +5165,7 @@ __metadata:
     "@backstage/dev-utils": "npm:^1.1.25"
     "@backstage/frontend-defaults": "npm:^0.5.4"
     "@backstage/frontend-plugin-api": "npm:^0.17.3"
+    "@backstage/frontend-test-utils": "npm:^0.6.2"
     "@backstage/plugin-catalog": "npm:^2.0.7"
     "@backstage/plugin-catalog-react": "npm:^3.2.0"
     "@backstage/plugin-search": "npm:^1.7.6"
@@ -13134,6 +13556,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.3.0":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5158,6 +5158,7 @@ __metadata:
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/cli": "npm:^0.36.4"
     "@backstage/cli-defaults": "npm:^0.1.4"
+    "@backstage/config-loader": "npm:^1.11.0"
     "@backstage/core-app-api": "npm:^1.20.3"
     "@backstage/core-compat-api": "npm:^0.5.13"
     "@backstage/core-components": "npm:^0.18.12"


### PR DESCRIPTION
## What changed

- add 112 behavioral specs across 18 suites
- verify Rootly client configuration and organization selection
- process the real Backstage config schema to ensure `apiKey` stays secret while runtime settings remain frontend-visible
- cover all supported Rootly annotations and overview/incidents routing precedence
- cover System child discovery, multi-organization aggregation, and partial Rootly failures
- cover all table families across loading, success, empty, error, linking, search, pagination, and catalog selection behavior
- instantiate alpha page, card, and content extensions in Backstage's extension test harness
- mount the real Rootly card through Backstage's entity-page test app and verify entity filtering
- verify page outlet overrides and application-provided Rootly API implementations
- migrate the alpha card's deprecated string filter to the supported entity predicate format
- enforce 75% statement and line, 70% branch, and 60% function coverage floors
- guarantee incident relationship helpers return arrays, correct Rootly layout diagnostics, and render true zero-incident card states
- run immutable install, lint, coverage/specs, build, and package dry-run on pull requests and pushes to `master`
- move both verification and release jobs to `blacksmith-2vcpu-ubuntu-2404`

## Why

The plugin previously had one export smoke test, and its verification suite only ran after a GitHub release was published. Configuration visibility, multi-organization routing, annotations, extension loading, and asynchronous UI behavior could regress without blocking a merge.

This establishes a useful contract-test baseline and makes it a pre-merge GitHub Actions gate.

## Validation

Validated locally using the same Node 24 and Yarn 4.9.4 toolchain configured in Actions:

- `yarn lint` (passes with 52 pre-existing React import warnings)
- `yarn test --watchAll=false --coverage --coverageReporters=text-summary`
  - 18 suites and 112 tests pass
  - 82.72% statements, 77.75% branches, 68.39% functions, 84.14% lines
- `yarn build`
- `npm pack --dry-run`

Blacksmith runner tags follow the documented Ubuntu 24.04 x64 instance label.
