### PR TITLE
Prepare 1.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @rootly/backstage-plugin
 
+## 1.3.3
+
+- Stabilize Rootly client identity to prevent repeated entity requests and render loops
+- Add Playwright browser coverage for Rootly routes, resources, and catalog integration
+- Run end-to-end tests on Blacksmith and retain Playwright reports
+- Align the development app with the React 18 and React Router 6 Backstage runtime
+
 ## 1.3.2
 
 - Allow the documented proxy-only Rootly configuration to pass strict validation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rootly/backstage-plugin",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump `@rootly/backstage-plugin` from 1.3.2 to 1.3.3
- document stable Rootly client identity and the entity render-loop fix
- document Playwright coverage and the Blacksmith end-to-end job
- document the Backstage-compatible React 18 / React Router 6 development harness

## Impact

This patch release fixes repeated Rootly client creation and entity requests without changing the public API. It also adds browser-level regression coverage and CI diagnostics.

## Validation

- immutable dependency install on Node 24
- lint (existing warnings only)
- 112 tests across 18 suites
- package build
- npm publish dry-run for `@rootly/backstage-plugin@1.3.3`

