### PR TITLE
Make npm publishing reproducible

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git tag or commit to publish
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -13,12 +19,13 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
       - run: corepack enable
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: yarn
-      - run: npm install -g npm@latest
       - run: corepack enable
       - run: yarn install --immutable
       - run: yarn lint


### PR DESCRIPTION
## Summary

- stop installing the moving `npm@latest` in the publish job
- use the Node 24 bundled npm, which already supports provenance publishing
- add a required ref input for manual recovery runs
- explicitly check out the release tag or requested recovery ref

## Root cause

The `v1.3.3` publish run resolved `npm@latest` to npm 12.0.2. That version requires Node 24.15 or newer, while `setup-node` resolved the `24` range to Node 24.13.0. The job failed before dependency installation, tests, or publishing.

## Recovery

After this merges, dispatch `Publish` with `ref=v1.3.3`. The workflow will check out the existing release tag and publish that exact package with provenance.

## Validation

- workflow passes Prettier validation
- release-equivalent install, lint, 112 tests, build, and npm publish dry-run passed locally for 1.3.3

