### PR TITLE
Use supported npm publish runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   publish:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    # npm trusted publishing and provenance reject self-hosted runners.
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- run only the npm publishing job on GitHub-hosted Ubuntu
- keep pull request verification and Playwright jobs on Blacksmith
- document why the publish runner is the necessary exception

## Root cause

npm rejected the signed 1.3.3 provenance bundle because Blacksmith is reported as a self-hosted GitHub Actions runner. npm trusted publishing and provenance currently support GitHub-hosted runners only.

## Validation

- Publish recovery passed immutable install, lint, 112 tests, build, and npm dry-run on Blacksmith
- failure occurred only at npm provenance verification
- workflow passes Prettier validation

## References

- https://docs.npmjs.com/trusted-publishers/
- https://docs.npmjs.com/generating-provenance-statements/

