### PR TITLE
Stabilize tests on npm publish runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,9 @@ jobs:
       - run: corepack enable
       - run: yarn install --immutable
       - run: yarn lint
-      - run: yarn test --watchAll=false
+      # The two-core hosted publish runner can starve Testing Library's async
+      # timers when Jest runs every suite concurrently.
+      - run: yarn test --watchAll=false --runInBand
       - run: yarn build
       - run: npm publish --dry-run --access public
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- run Jest serially in the npm publish job
- avoid Testing Library async timer starvation on the two-core GitHub-hosted runner
- retain the full lint, 112-test, build, and npm dry-run gates before publication

## Context

The v1.3.3 publish job reproducibly passed 111/112 tests but timed out on one async overview-card assertion when Jest ran suites concurrently. The same tagged code passes on the Blacksmith verification runners. npm trusted publishing/provenance requires the publish job itself to remain GitHub-hosted.

## Verification

- `git diff --check`
- GitHub Actions verify/e2e checks (pending)
- final publish workflow will exercise the serial test command against `v1.3.3` before publishing